### PR TITLE
ui: Getting logged out when searching for an image

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Set or adjust these values in your `settings_local.dev.py` and/or `settings_loca
   - Allows you to turn off signup through the API by setting to `False` if you would like to use Badgr for only single-account use or to manually create all users in `/staff`. The default is `True` (signup API is enabled). UX is not well-supported in the `/staff` interface.
 * `DEFAULT_FILE_STORAGE` and `MEDIA_URL`:
   - Django supports various backends for storing media, as applicable for your deployment strategy. See Django docs on the [file storage API](https://docs.djangoproject.com/en/1.11/ref/files/storage/)
+* `NOUNPROJECT_API_KEY` and `NOURNPROJECT_SECRET`:
+  - Set these values to be able to search for icons with in the badge creation process.
 
 ### Running the Django Server in Development
 

--- a/apps/mainsite/views.py
+++ b/apps/mainsite/views.py
@@ -50,7 +50,7 @@ def error404(request, *args, **kwargs):
     try:
         template = loader.get_template('error/404.html')
     except TemplateDoesNotExist:
-        return HttpResponseServerError('<h1>Pagse not found (404)</h1>', content_type='text/html')
+        return HttpResponseServerError('<h1>Page not found (404)</h1>', content_type='text/html')
     return HttpResponseNotFound(template.render({
         'STATIC_URL': getattr(settings, 'STATIC_URL', '/static/'),
     }))
@@ -94,11 +94,19 @@ def nounproject(req, searchterm, page):
             if response.status_code == 200:
                 data = response.json()
                 return JsonResponse(data, status=status.HTTP_200_OK)
+            elif response.status_code == 403:
+                # Probably the API KEY / SECRET was wrong
+                return JsonResponse({"error":
+                    "Couldn't authenticate against thenounproject!"},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR)
             else:
                 attempt_num += 1
                 # You can probably use a logger to log the error here
                 time.sleep(5)  # Wait for 5 seconds before re-trying
-        return JsonResponse({"error": "Request failed"}, status=response.status_code)
+
+        return JsonResponse({"error":
+            f"Request failed with status code {response.status_code}"},
+            status=response.status_code)
     else:
         return JsonResponse({"error": "Method not allowed"}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/apps/mainsite/views.py
+++ b/apps/mainsite/views.py
@@ -89,7 +89,7 @@ def nounproject(req, searchterm, page):
         attempt_num = 0  # keep track of how many times we've retried
         while attempt_num < 4:
             auth = OAuth1(getattr(settings, 'NOUNPROJECT_API_KEY'), getattr(settings, 'NOUNPROJECT_SECRET'))
-            endpoint = "http://api.thenounproject.com/icons/"+ searchterm +"?limit=10&page="+page
+            endpoint = "http://api.thenounproject.com/v2/icon?query="+ searchterm +"?limit=10&page="+page
             response = requests.get(endpoint, auth=auth)
             if response.status_code == 200:
                 data = response.json()


### PR DESCRIPTION
- Add information on NOUNPROJECT API settings to README
- Don't return 403 when authentication to thenounproject failed, thus not logging the user out of the ui
- Use thenounproject api v2, since v1 is deprecated and not accessible for new users anymore (also note the necessary [changes](https://github.com/mint-o-badges/badgr-ui/pull/6) in the ui)