### PR TITLE
Don't hardcode backend url in mail template

### DIFF
--- a/apps/mainsite/templates/issuer/email/notify_admins_message.html
+++ b/apps/mainsite/templates/issuer/email/notify_admins_message.html
@@ -1,3 +1,3 @@
 Hallo Admins,
 
-eine neue Institution ("{{ issuer_name }}") wurde erstellt. Bitte <a href="https://api.openbadges.education/staff/issuer/issuer/">verifiziereren</a> Sie diese.
+eine neue Institution ("{{ issuer_name }}") wurde erstellt. Bitte <a href="{{ HTTP_ORIGIN }}/staff/issuer/issuer/">verifiziereren</a> Sie diese.


### PR DESCRIPTION
For the extensions it seems to actually make sense for them to be hardcoded, since they're a part of the information stored in a badge. So maybe it's worth discussing if this should actually be changed.