### PR TITLE
include extensions in backpack serializer

### DIFF
--- a/apps/backpack/serializers_v1.py
+++ b/apps/backpack/serializers_v1.py
@@ -46,6 +46,9 @@ class LocalBadgeInstanceUploadSerializerV1(serializers.Serializer):
             self.fields.json = serializers.DictField(read_only=True)
         representation = super(LocalBadgeInstanceUploadSerializerV1, self).to_representation(obj)
 
+        representation['extensions']["extensions:CompetencyExtension"] = obj.badgeclass.json['extensions:CompetencyExtension']
+        representation['extensions']["extensions:CategoryExtension"] = obj.badgeclass.json['extensions:CategoryExtension']
+
         representation['id'] = obj.entity_id
         representation['json'] = V1BadgeInstanceSerializer(obj, context=self.context).data
         representation['imagePreview'] = {


### PR DESCRIPTION
The endpoint ```v1/earner/badges``` from the backpack app did not include extensions in its response, it only returned an empty object for the extensions key