### PR TITLE
Fix: Migrate django to v3 build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -107,6 +107,9 @@ requests-cache==0.5.2
 importlib-resources==5.10.0 # Normally v6.0.1 is installed but Django is not working with it
 
 geopy==2.2.0
+
+# Install wheel to fix the installation error for uwsgi
+wheel
 uwsgi
 
 tox


### PR DESCRIPTION
Also install wheel. This seems to fix the error locally; Whether it works for the github build we'll see once this is merged.

**EDIT: Since the build for the check succeeded, this should prove that the fix works.**