### PR TITLE
chore(actions): add workflows to cleanup docker images

### DIFF
--- a/.github/workflows/registry-purge-pr.yml
+++ b/.github/workflows/registry-purge-pr.yml
@@ -1,0 +1,19 @@
+name: 🗑️ Purge Pull Request Image
+
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+# Purge Pull Request Image if pull request gets closed
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  purge_pr_image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 💣 Purge Pull Request Image
+        uses: vlaurin/action-ghcr-prune@v0.6.0
+        with:
+          token: ${{ secrets.GHCR_TOKEN}}
+          organization: ${{ github.repository_owner}}
+          container: ${{ github.event.repository.name }}
+          prune-tags-regexes: pr-${{github.event.pull_request.number}}$

--- a/.github/workflows/registry-purge-pr.yml
+++ b/.github/workflows/registry-purge-pr.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  packages: write
+
 jobs:
   purge_pr_image:
     runs-on: ubuntu-latest
@@ -13,7 +16,7 @@ jobs:
       - name: 💣 Purge Pull Request Image
         uses: vlaurin/action-ghcr-prune@v0.6.0
         with:
-          token: ${{ secrets.GHCR_TOKEN}}
+          token: ${{ secrets.GITHUB_TOKEN}}
           organization: ${{ github.repository_owner}}
           container: ${{ github.event.repository.name }}
           prune-tags-regexes: pr-${{github.event.pull_request.number}}$

--- a/.github/workflows/registry-purge.yml
+++ b/.github/workflows/registry-purge.yml
@@ -1,0 +1,19 @@
+name: 🗑️ Purge untagged images
+
+# https://docs.github.com/en/actions/reference/events-that-trigger-workflows#registry_package
+# Run cleanup job every day
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  purge_untagged_images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 💣 Purge untagged images
+        uses: vlaurin/action-ghcr-prune@v0.6.0
+        with:
+          token: ${{ secrets.GHCR_TOKEN }}
+          organization: ${{ github.repository_owner }}
+          container: ${{ github.event.repository.name }}
+          prune-untagged: true

--- a/.github/workflows/registry-purge.yml
+++ b/.github/workflows/registry-purge.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  packages: write
+
 jobs:
   purge_untagged_images:
     runs-on: ubuntu-latest
@@ -13,7 +16,7 @@ jobs:
       - name: 💣 Purge untagged images
         uses: vlaurin/action-ghcr-prune@v0.6.0
         with:
-          token: ${{ secrets.GHCR_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           organization: ${{ github.repository_owner }}
           container: ${{ github.event.repository.name }}
           prune-untagged: true


### PR DESCRIPTION
This PR includes two new Github action workflows to delete images from the registry and closes #56 

`registry-purge-pr`: will delete the pull request image after a pull request is closed
`registry-purge`: will run every day to delete untagged images from the registry