### PR TITLE
chore(actions): extend build workflow to generate release

### DIFF
--- a/.github/workflows/registry-build-push.yml
+++ b/.github/workflows/registry-build-push.yml
@@ -13,8 +13,37 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+
+  create-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create-release.outputs.result }}
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: ⬇️ Checkout repository
+        uses: actions/checkout@v4.1.3
+
+      - name: 📋 Create release
+        id: create-release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `${{ github.ref_name }}`,
+              name: `${{ github.ref_name }}`,
+              generate_release_notes: true,
+              draft: true,
+              prerelease: false
+            })
+
+            return data.id
+
   build-and-push-image:
-    name:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -51,3 +80,25 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  publish-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: [create-release, build-and-push-image]
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: 🚢 Publish release
+        uses: actions/github-script@v6
+        env:
+          release_id: ${{ needs.create-release.outputs.release_id }}
+        with:
+          script: |
+            github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: process.env.release_id,
+              draft: false,
+              prerelease: false
+            })


### PR DESCRIPTION
This PR will create a new release and attached release notes generated from commit messages if a `tag` is available on `main` branch.

closes #55 