### PR TITLE
Fix/password reset

### DIFF
--- a/apps/badgeuser/api.py
+++ b/apps/badgeuser/api.py
@@ -353,7 +353,7 @@ class BadgeUserForgotPassword(BaseUserRecoveryView):
         except DjangoValidationError as e:
             return Response(dict(password=e.messages), status=HTTP_400_BAD_REQUEST)
 
-        cache.delete(backoff_cache_key(user.email))
+        cache.delete_many([backoff_cache_key(user.email)])
 
         user.set_password(password)
         user.save()

--- a/apps/badgeuser/api.py
+++ b/apps/badgeuser/api.py
@@ -353,7 +353,11 @@ class BadgeUserForgotPassword(BaseUserRecoveryView):
         except DjangoValidationError as e:
             return Response(dict(password=e.messages), status=HTTP_400_BAD_REQUEST)
 
+        # use delete many due to an incompatibility with python-memcached and django v3.2
+        # TODO: maybe replace python-memcached with pylibmc  
         cache.delete_many([backoff_cache_key(user.email)])
+        # cache.delete(backoff_cache_key(user.email))
+
 
         user.set_password(password)
         user.save()


### PR DESCRIPTION
I think the problem with resetting the password was caused by an incompatibility between ```django v3.2``` and the ```python-memcached``` library that we use. In the [django release notes](https://docs.djangoproject.com/en/5.0/releases/3.2/#features-deprecated-in-3-2) the ```django.core.cache.backends.memcached.MemcachedCache```  was marked as deprecated, two alternatives are listed here. For now i found a workaround for the password reset functionality, but we should invest some time soon in replacing our memcached client library.  