### PR TITLE
Check that only verified issuers create badges

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -649,6 +649,20 @@ class BadgeClass(ResizeUploadedImage,
 
     class Meta:
         verbose_name_plural = "Badge classes"
+    
+    def save(self, *args, **kwargs):
+        # It's best practice to run full clean on saving. This (also) runs
+        # The clean method you find below
+        self.full_clean()
+        return super().save(*args, **kwargs)
+    
+    def clean(self):
+        # Check if the issuer for this badge is verified, otherwise throw an error
+        if not self.issuer.verified:
+            raise ValidationError(
+                "Only verified issuers can create / update badges",
+                code="invalid"
+            )
 
     def publish(self):
         fields_cache = self._state.fields_cache  # stash the fields cache to avoid publishing related objects here


### PR DESCRIPTION
This is the backend check corresponding to the frontend button disabling. This check throws an error, in the end bubbling in a 500 error if the user somehow manages to invoke a badge creation with an unverified issuer. This shows as a simple error message in the frontend (if DEBUG is disabled).