### PR TITLE
fix: full_clean validation fails due to entity_id and old_json not ha…

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -651,9 +651,7 @@ class BadgeClass(ResizeUploadedImage,
         verbose_name_plural = "Badge classes"
     
     def save(self, *args, **kwargs):
-        # It's best practice to run full clean on saving. This (also) runs
-        # The clean method you find below
-        self.full_clean()
+        self.clean()
         return super().save(*args, **kwargs)
     
     def clean(self):


### PR DESCRIPTION
fixes badge creation / badge editing. It did not work because the validation of the ``` full_clean``` method failed on the fields for ```entity_id``` and ```old_json```. I simply replaced it with the ```clean``` method for now, another option would be to provide default values for these fields. I am not sure if this could lead to other problems, i think using just ```clean```should be fine for us. 