### PR TITLE
Feat/replace memcached client lib

### DIFF
--- a/.docker/etc/settings_local.dev.py.example
+++ b/.docker/etc/settings_local.dev.py.example
@@ -41,7 +41,7 @@ DATABASES = {
 ###
 CACHES = {
      'default': {
-         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
          'LOCATION': 'memcached:11211',
          'KEY_FUNCTION': 'mainsite.utils.filter_cache_key'
      }

--- a/.docker/etc/settings_local.prod.py.example
+++ b/.docker/etc/settings_local.prod.py.example
@@ -41,7 +41,7 @@ DATABASES = {
 ###
 CACHES = {
      'default': {
-         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
          'LOCATION': 'memcached:11211',
          'KEY_FUNCTION': 'mainsite.utils.filter_cache_key'
      }

--- a/apps/badgeuser/api.py
+++ b/apps/badgeuser/api.py
@@ -354,10 +354,7 @@ class BadgeUserForgotPassword(BaseUserRecoveryView):
             return Response(dict(password=e.messages), status=HTTP_400_BAD_REQUEST)
 
 
-        # use delete many due to an incompatibility with python-memcached and django v3.2
-        # TODO: maybe replace python-memcached with pylibmc  
-        cache.delete_many([backoff_cache_key(user.email)])
-        # cache.delete(backoff_cache_key(user.email))
+        cache.delete(backoff_cache_key(user.email))
         
 
         user.set_password(password)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ django-basic-models==4.0.0
 
 django-object-actions==1.1.0
 
-python-memcached==1.58
+pymemcache 
 
 djangorestframework==3.12.2
 


### PR DESCRIPTION
This PR replaces the deprecated ```python-memcached``` library with ```pymemcache```. It seems to be more or less a drop-in-replacement. I tested the new library on the ```develop``` environment and it seems to work (e.g. the password reset works without the ```delete_many``` hack). 