### PR TITLE
revert: bump drf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ django-object-actions==1.1.0
 
 pymemcache 
 
-djangorestframework==3.15.1
+djangorestframework==3.12.2
 
 # Django Allauth
 django-allauth==0.63.3


### PR DESCRIPTION
Updating ```djangorestframework``` causes an error, because ```NullBooleanField``` was removed in 3.14. 