### PR TITLE
Fix/migrations

### DIFF
--- a/apps/badgrsocialauth/adapter.py
+++ b/apps/badgrsocialauth/adapter.py
@@ -4,7 +4,7 @@ import urllib.parse
 import urllib.error
 
 from allauth.account.utils import user_email
-from allauth.exceptions import ImmediateHttpResponse
+from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from django.conf import settings
 from django.http import HttpResponseForbidden, HttpResponseRedirect

--- a/apps/mainsite/account_adapter.py
+++ b/apps/mainsite/account_adapter.py
@@ -7,7 +7,7 @@ import urllib.parse
 from allauth.account.adapter import DefaultAccountAdapter, get_adapter
 from allauth.account.models import EmailConfirmation, EmailConfirmationHMAC
 from allauth.account.utils import user_pk_to_url_str
-from allauth.exceptions import ImmediateHttpResponse
+from allauth.core.exceptions import ImmediateHttpResponse
 from django.conf import settings
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,7 +40,7 @@ services:
 
   # this container runs mysql (database)
   db:
-    image: mysql:5.6.39
+    image: mysql:5.7.31
     volumes:
       - badgr_server_prod_db:/var/lib/mysql:rw
       - ./.docker/etc/init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   # this container runs mysql (database)
   db:
-    image: mysql:5.6.39
+    image: mysql:5.7.31
     # platform: linux/amd64 comment in if you are on Apple Silicon
     volumes:
       - badgr_server_dev_db:/var/lib/mysql:rw


### PR DESCRIPTION
This PR includes: 
- upgrading mysql version to 5.7.31, which supports ```JSONField``` 
- using ```allauth.core.exceptions``` instead of deprecated ```allauth.exceptions``` 

After upgrading to mysql 5.7.31 i got a lot of warnings: ```InnoDB: Table mysql/innodb_index_stats has length mismatch in the column name table_name.  Please run mysql_upgrade` ```

To fix run : 
-  ``` docker compose exec db /bin/bash```
- check if mysql version is 5.7.31: ``` mysql --version``` 
- run upgrade: ```mysql_upgrade -u root -p``` 
-  Enter ```MYSQL_ROOT_PASSWORD``` from ```docker-compose.yml```