### PR TITLE
Revert/django allauth upgrade

### DIFF
--- a/apps/badgrsocialauth/adapter.py
+++ b/apps/badgrsocialauth/adapter.py
@@ -4,7 +4,7 @@ import urllib.parse
 import urllib.error
 
 from allauth.account.utils import user_email
-from allauth.core.exceptions import ImmediateHttpResponse
+from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from django.conf import settings
 from django.http import HttpResponseForbidden, HttpResponseRedirect

--- a/apps/mainsite/account_adapter.py
+++ b/apps/mainsite/account_adapter.py
@@ -7,7 +7,7 @@ import urllib.parse
 from allauth.account.adapter import DefaultAccountAdapter, get_adapter
 from allauth.account.models import EmailConfirmation, EmailConfirmationHMAC
 from allauth.account.utils import user_pk_to_url_str
-from allauth.core.exceptions import ImmediateHttpResponse
+from allauth.exceptions import ImmediateHttpResponse
 from django.conf import settings
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -67,8 +67,6 @@ MIDDLEWARE = [
     'mainsite.middleware.XframeExempt500Middleware',
     'mainsite.middleware.MaintenanceMiddleware',
     'badgeuser.middleware.InactiveUserMiddleware',
-    # Since allauth 0.56.0 this middleware needs to be present
-    'allauth.account.middleware.AccountMiddleware',
     # 'mainsite.middleware.TrailingSlashMiddleware',
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pymemcache
 djangorestframework==3.12.2
 
 # Django Allauth
-django-allauth==0.63.3
+django-allauth==0.46.0
 oauthlib==3.1.0
 requests==2.25.0
 requests-oauthlib==0.4.2


### PR DESCRIPTION
Upgrading ```django-allauth``` causes this warning:  

```
WARNINGS:
badgr-server-api-1        | ?: adapter.get_email_confirmation_redirect_url(request) is deprecated, use adapter.get_email_verification_redirect_url(email_address)
```

Also, registration fails. We didnt manage to fix the warning, so we roll back for now