### PR TITLE
fix: remove python-memcached dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,8 @@ django-basic-models==4.0.0
 
 django-object-actions==1.1.0
 
-python-memcached
-pymemcache 
+#python-memcached==1.62
+pymemcache==4.0.0
 
 djangorestframework==3.12.2
 


### PR DESCRIPTION
We changed our cache backend from python-memcached to pymemcache. I then wasn't aware that it also needed to be changed in the settings and added the other dependency again. So with this commit I'm removing the dependency (again). This also seems to solve the original issue, that re-creating a user does not work.

If the project doesn't compile for you anymore,
remember to change the settings accordingly
(similar to the example settings' CACHE section).