### PR TITLE
feat: use name stored in badge if possible

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -1006,7 +1006,6 @@ class BadgeInstance(BaseAuditedModel,
 
     # slug has been deprecated for now, but preserve existing values
     slug = models.CharField(max_length=255, db_index=True, blank=True, null=True, default=None)
-    # slug = AutoSlugField(max_length=255, populate_from='get_new_slug', unique=True, blank=False, editable=False)
 
     revoked = models.BooleanField(default=False, db_index=True)
     revocation_reason = models.CharField(max_length=255, blank=True, null=True, default=None)

--- a/apps/mainsite/account_adapter.py
+++ b/apps/mainsite/account_adapter.py
@@ -23,7 +23,7 @@ import badgrlog
 from badgrsocialauth.utils import set_session_badgr_app
 from mainsite.models import BadgrApp, EmailBlacklist, AccessTokenProxy
 from mainsite.utils import OriginSetting, set_url_query_params
-from backpack.views import add_recipient_name, add_title, add_description, addBadgeImage, add_issuerImage, add_issuedBy, RoundedRectFlowable, AllPageSetup, PageNumCanvas
+from backpack.views import get_name, add_recipient_name, add_title, add_description, addBadgeImage, add_issuerImage, add_issuedBy, RoundedRectFlowable, AllPageSetup, PageNumCanvas
 from reportlab.lib.pagesizes import A4
 from reportlab.platypus import SimpleDocTemplate, Table, Paragraph, Spacer, PageBreak
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
@@ -48,22 +48,15 @@ class BadgrAccountAdapter(DefaultAccountAdapter):
         except BadgeClass.DoesNotExist:
             raise ValueError("BadgeClass not found")
 
-        badgeuser = None
-        try: 
-            badgeuser = BadgeUser.objects.get(email=badgeinstance.recipient_identifier)  
+        name = None
+        try:
+            name = get_name(badgeinstance)
         except BadgeUser.DoesNotExist:
             logger = logging.getLogger(__name__)
             logger.warning("Could not find badgeuser")
         
         first_page_content = []
-        if badgeuser is not None: 
-            first_name = badgeuser.first_name.capitalize()
-            last_name = badgeuser.last_name.capitalize()
-            add_recipient_name(first_page_content, first_name, last_name, badgeinstance.issued_on) 
-        else: 
-            first_name = None
-            last_name = None
-            add_recipient_name(first_page_content, badgeinstance.recipient_identifier, '', badgeinstance.issued_on)    
+        add_recipient_name(first_page_content, name, badgeinstance.issued_on) 
 
         competencies = badgeclass.json["extensions:CompetencyExtension"]
 


### PR DESCRIPTION
This applies to the PDF export only, since I couldn't find any other place where we could use the name stored in the badge.