### PR TITLE
fix: remove special chars from site_name

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -583,7 +583,7 @@ class Issuer(ResizeUploadedImage,
                 'issuer_name': re.sub(r'[^\w\s]+', '', self.name, 0, re.I),
                 'issuer_url': self.url,
                 'issuer_email': self.email,
-                'site_name': badgr_app.name,
+                'site_name': re.sub(r'[^\w\s]+', '', badgr_app.name, 0, re.I),
                 'badgr_app': badgr_app
             }
         except KeyError as e:

--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -583,7 +583,7 @@ class Issuer(ResizeUploadedImage,
                 'issuer_name': re.sub(r'[^\w\s]+', '', self.name, 0, re.I),
                 'issuer_url': self.url,
                 'issuer_email': self.email,
-                'site_name': re.sub(r'[^\w\s]+', '', badgr_app.name, 0, re.I),
+                'site_name': re.sub(r'@', '', badgr_app.name),
                 'badgr_app': badgr_app
             }
         except KeyError as e:


### PR DESCRIPTION
If the issuer name contains an "@" symbol, the site_name will also contain the "@" which causes the ```set_email_string``` function (```account_adapter.py``` l. 196) to return an invalid email. 