### PR TITLE
feat: add prometheus metrics endpoint

### DIFF
--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.admin',
     'django_object_actions',
+    'django_prometheus',
     'markdownify',
 
 
@@ -62,6 +63,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -74,6 +76,7 @@ MIDDLEWARE = [
     'mainsite.middleware.MaintenanceMiddleware',
     'badgeuser.middleware.InactiveUserMiddleware',
     # 'mainsite.middleware.TrailingSlashMiddleware',
+    'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]
 
 ROOT_URLCONF = 'mainsite.urls'

--- a/apps/mainsite/urls.py
+++ b/apps/mainsite/urls.py
@@ -196,6 +196,9 @@ urlpatterns = [
     url(r'^oidcview/logoutRedirect/', OidcView.oidcLogoutRedirect, name="oidcLogoutRedirect"),
 
     url(r"^altcha", createCaptchaChallenge, name="create_captcha_challenge"),
+
+    # Prometheus endpoint
+    path('', include('django_prometheus.urls')),
 ]
 # add to serve files
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ puremagic==1.6
 sqlparse==0.3.0
 netaddr
 defusedxml
+django-prometheus==2.3.1
 
 # Utilities for working with badges
 jsonschema==2.6.0


### PR DESCRIPTION
This PR enables a Prometheus-compatible endpoint `/metrics` for the Django application. The endpoint is enabled by the [django-prometheus](https://github.com/korfuri/django-prometheus) library.

As a starting point, it only monitors requests and responses, but the library can also monitor database and cache access.

To secure the `/metrics` endpoint a specific auth middleware must be applied by `labels` to the service in the docker-compose file.

