### PR TITLE
Fix/netlify previews stopped working

### DIFF
--- a/apps/mainsite/apps.py
+++ b/apps/mainsite/apps.py
@@ -1,14 +1,5 @@
 from django.apps import AppConfig
 from django.conf import settings
 
-from corsheaders.signals import check_request_enabled
-
-
 class BadgrConfig(AppConfig):
     name = 'mainsite'
-
-    def ready(self):
-        # Makes sure all signal handlers are connected
-        if getattr(settings, 'BADGR_CORS_MODEL'):
-            from mainsite.signals import cors_allowed_sites
-            check_request_enabled.connect(cors_allowed_sites)

--- a/apps/mainsite/models.py
+++ b/apps/mainsite/models.py
@@ -134,6 +134,10 @@ class BadgrAppManager(cachemodel.CacheModelManager):
 
 class BadgrApp(CreatedUpdatedBy, CreatedUpdatedAt, IsActive, cachemodel.CacheModel):
     name = models.CharField(max_length=254)
+    # Note that this is NOT used for CORS anymore! It is rather
+    # used as the base url and only exists for legacy reasons.
+    # TODO: Do we even need this anymore? Do we *need* anything
+    # from this BadgrApp anymore?
     cors = models.CharField(max_length=254, unique=True)
     is_default = models.BooleanField(default=False)
     email_confirmation_redirect = models.URLField()

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -65,8 +65,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'corsheaders.middleware.CorsMiddleware',
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     # It's important that CookieToBearerMiddleware comes before
@@ -225,8 +225,6 @@ AUTH_PASSWORD_VALIDATORS = [
 #
 ##
 
-# CORS_ORIGIN_ALLOW_ALL = True
-CORS_URLS_REGEX = r'^.*$'
 # Needed for authentication
 CORS_ALLOW_CREDENTIALS = True
 

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -65,8 +65,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'corsheaders.middleware.CorsMiddleware',
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     # It's important that CookieToBearerMiddleware comes before

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -227,7 +227,6 @@ AUTH_PASSWORD_VALIDATORS = [
 
 # CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r'^.*$'
-BADGR_CORS_MODEL = 'mainsite.BadgrApp'
 # Needed for authentication
 CORS_ALLOW_CREDENTIALS = True
 

--- a/apps/mainsite/signals.py
+++ b/apps/mainsite/signals.py
@@ -1,20 +1,6 @@
-from urllib.parse import urlparse
-
-from django.apps import apps
-from django.conf import settings
-
 from mainsite.models import AccessTokenScope
-from mainsite.utils import netloc_to_domain
-
-
-CorsModel = apps.get_model(getattr(settings, 'BADGR_CORS_MODEL'))
-
 
 def handle_token_save(sender, instance=None, **kwargs):
     for s in instance.scope.split():
         AccessTokenScope.objects.get_or_create(token=instance, scope=s)
 
-
-def cors_allowed_sites(sender, request, **kwargs):
-    origin = netloc_to_domain(urlparse(request.META['HTTP_ORIGIN']).netloc)
-    return CorsModel.objects.filter(cors=origin).exists()


### PR DESCRIPTION
Remove cors from application level
I've already reconfigured the settings on the servers so that merging this shouldn't cause the CORS config to work. This allows for the CORS regex to be configured on the staging server, so that netlify previews can be allowed.

The adjustments I made on staging already cause the netlify preview to work again. This PR merely removes a duplicate configuration of CORS that we don't need anymore.