### PR TITLE
fix(import): fix unverified created issuer not being able to create badge

### DIFF
--- a/apps/backpack/serializers_v1.py
+++ b/apps/backpack/serializers_v1.py
@@ -46,9 +46,13 @@ class LocalBadgeInstanceUploadSerializerV1(serializers.Serializer):
             self.fields.json = serializers.DictField(read_only=True)
         representation = super(LocalBadgeInstanceUploadSerializerV1, self).to_representation(obj)
 
-        representation['extensions']["extensions:CompetencyExtension"] = obj.badgeclass.json['extensions:CompetencyExtension']
-        representation['extensions']["extensions:CategoryExtension"] = obj.badgeclass.json['extensions:CategoryExtension']
-        representation['extensions']["extensions:StudyLoadExtension"] = obj.badgeclass.json['extensions:StudyLoadExtension']
+        # supress errors for badges without extensions (i.e. imported)
+        try:
+            representation['extensions']["extensions:CompetencyExtension"] = obj.badgeclass.json['extensions:CompetencyExtension']
+            representation['extensions']["extensions:CategoryExtension"] = obj.badgeclass.json['extensions:CategoryExtension']
+            representation['extensions']["extensions:StudyLoadExtension"] = obj.badgeclass.json['extensions:StudyLoadExtension']
+        except KeyError:
+            pass
 
         representation['id'] = obj.entity_id
         representation['json'] = V1BadgeInstanceSerializer(obj, context=self.context).data

--- a/apps/issuer/helpers.py
+++ b/apps/issuer/helpers.py
@@ -251,6 +251,8 @@ class BadgeCheckHelper(object):
             with transaction.atomic():
                 issuer, issuer_created = Issuer.objects.get_or_create_from_ob2(
                     issuer_obo, original_json=original_json.get(issuer_obo.get('id')), image=issuer_image)
+                # set issuer as verified temporarily so the badge can be created
+                issuer.verified = True
                 badgeclass, badgeclass_created = BadgeClass.objects.get_or_create_from_ob2(
                     issuer, badgeclass_obo,
                     original_json=original_json.get(badgeclass_obo.get('id')),


### PR DESCRIPTION
Importing badges from external sources is currently broken because the newly created issuer will be unverified and thus not allowed to create badges. 
The LocalBadgeInstanceUploadSerializerV1 crashed for badges without our extensions.