### PR TITLE
Feat/api v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ dist/
 htmlcov/
 api_spec_v1.json
 api_spec_v2.json
+api_spec_v3.json
 api_spec_bcv1.json
 
 django.log

--- a/apps/backpack/api_v3.py
+++ b/apps/backpack/api_v3.py
@@ -1,0 +1,40 @@
+from entity.api_v3 import EntityViewSet
+from backpack.serializers_v2 import BackpackAssertionSerializerV2
+from issuer.permissions import BadgrOAuthTokenHasScope, VerifiedEmailMatchesRecipientIdentifier
+from issuer.serializers_v1 import LearningPathSerializerV1
+from issuer.models import BadgeInstance, LearningPath, LearningPathBadge
+from mainsite.permissions import AuthenticatedWithVerifiedIdentifier
+
+class Badges(EntityViewSet):
+    serializer_class = BackpackAssertionSerializerV2
+
+    valid_scopes = {
+        'get': ['r:backpack', 'rw:backpack'],
+        'post': ['rw:backpack'],
+    }
+    permission_classes = (
+        AuthenticatedWithVerifiedIdentifier,
+        VerifiedEmailMatchesRecipientIdentifier,
+        BadgrOAuthTokenHasScope
+    )
+
+    def get_queryset(self):
+        return self.request.user.cached_badgeinstances()
+
+class LearningPaths(EntityViewSet):
+    serializer_class = LearningPathSerializerV1
+
+    valid_scopes = ["rw:backpack"]
+    permission_classes = (
+        AuthenticatedWithVerifiedIdentifier,
+        VerifiedEmailMatchesRecipientIdentifier,
+        BadgrOAuthTokenHasScope
+    )
+
+    def get_queryset(self):
+        badgeinstances = self.request.user.cached_badgeinstances().all()
+        badges = list({badgeinstance.badgeclass for badgeinstance in badgeinstances})
+        lp_badges = LearningPathBadge.objects.filter(badge__in=badges)
+        lps = LearningPath.objects.filter(learningpathbadge__in=lp_badges).distinct()
+
+        return lps

--- a/apps/backpack/serializers_v2.py
+++ b/apps/backpack/serializers_v2.py
@@ -151,8 +151,12 @@ class BackpackAssertionSerializerV2(DetailSerializerV2, OriginalJsonSerializerMi
 
     def to_representation(self, instance):
         representation = super(BackpackAssertionSerializerV2, self).to_representation(instance)
-        request_kwargs = self.context['kwargs']
-        expands = request_kwargs.get('expands', [])
+        
+        try:
+            request_kwargs = self.context['kwargs']
+            expands = request_kwargs.get('expands', [])
+        except:
+            expands = []
 
         if self.parent is not None:
             # we'll have a bare representation

--- a/apps/backpack/v3_api_urls.py
+++ b/apps/backpack/v3_api_urls.py
@@ -6,9 +6,8 @@ from rest_framework import routers
 from . import api_v3
 
 router = routers.DefaultRouter()
-router.register(r'badges', api_v3.Badges)
-router.register(r'issuers', api_v3.Issuers)
-router.register(r'learningpaths', api_v3.LearningPaths)
+router.register(r'badges', api_v3.Badges, basename='badges')
+router.register(r'learningpaths', api_v3.LearningPaths, basename='learningpaths')
 
 urlpatterns = [
 	path('', include(router.urls)),

--- a/apps/entity/api_v3.py
+++ b/apps/entity/api_v3.py
@@ -1,0 +1,19 @@
+from rest_framework import viewsets
+from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.filters import OrderingFilter
+from django_filters import rest_framework as filters
+
+
+class EntityLimitOffsetPagination(LimitOffsetPagination):
+    default_limit = 20
+
+class EntityFilter(filters.FilterSet):
+    name = filters.CharFilter(field_name='name', lookup_expr='icontains')
+
+class EntityViewSet(viewsets.ModelViewSet):
+    pagination_class = EntityLimitOffsetPagination
+    http_method_names = ['get', 'head', 'options']
+    lookup_field = 'entity_id'
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    filterset_class = EntityFilter
+    ordering_fields = ['name', 'created_at']

--- a/apps/issuer/api_v3.py
+++ b/apps/issuer/api_v3.py
@@ -1,5 +1,7 @@
 from rest_framework import viewsets, mixins
 from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.filters import OrderingFilter
+from django_filters import rest_framework as filters
 
 from apispec_drf.decorators import apispec_list_operation, apispec_post_operation, apispec_get_operation, \
     apispec_delete_operation, apispec_put_operation, apispec_operation
@@ -7,14 +9,28 @@ from apispec_drf.decorators import apispec_list_operation, apispec_post_operatio
 from .serializers_v1 import BadgeClassSerializerV1, IssuerSerializerV1, LearningPathSerializerV1
 from .models import BadgeClass, Issuer, LearningPath
 
+
+class EntityFilter(filters.FilterSet):
+    name = filters.CharFilter(field_name='name', lookup_expr='icontains')
+
+class BadgeFilter(EntityFilter):
+    tags = filters.CharFilter(field_name='badgeclasstag__name', lookup_expr='icontains')
+
+class LearningPathFilter(EntityFilter):
+    tags = filters.CharFilter(field_name='learningpathtag__name', lookup_expr='icontains')
+
 class EntityViewSet(viewsets.ModelViewSet):
     pagination_class = LimitOffsetPagination
     http_method_names = ['get', 'head', 'options']
     lookup_field = 'entity_id'
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    filterset_class = EntityFilter
+    ordering_fields = ['name', 'created_at']
 
 class Badges(EntityViewSet):
     queryset = BadgeClass.objects.all()
     serializer_class = BadgeClassSerializerV1
+    filterset_class = BadgeFilter
 
     # only for apispec, get() does nothing on viewset
     @apispec_list_operation('BadgeClass',
@@ -29,5 +45,6 @@ class Issuers(EntityViewSet):
     serializer_class = IssuerSerializerV1
 
 class LearningPaths(EntityViewSet):
-    queryset = Issuer.objects.all()
+    queryset = LearningPath.objects.all()
     serializer_class = LearningPathSerializerV1
+    filterset_class = LearningPathFilter

--- a/apps/issuer/api_v3.py
+++ b/apps/issuer/api_v3.py
@@ -1,0 +1,33 @@
+from rest_framework import viewsets, mixins
+from rest_framework.pagination import LimitOffsetPagination
+
+from apispec_drf.decorators import apispec_list_operation, apispec_post_operation, apispec_get_operation, \
+    apispec_delete_operation, apispec_put_operation, apispec_operation
+
+from .serializers_v1 import BadgeClassSerializerV1, IssuerSerializerV1, LearningPathSerializerV1
+from .models import BadgeClass, Issuer, LearningPath
+
+class EntityViewSet(viewsets.ModelViewSet):
+    pagination_class = LimitOffsetPagination
+    http_method_names = ['get', 'head', 'options']
+    lookup_field = 'entity_id'
+
+class Badges(EntityViewSet):
+    queryset = BadgeClass.objects.all()
+    serializer_class = BadgeClassSerializerV1
+
+    # only for apispec, get() does nothing on viewset
+    @apispec_list_operation('BadgeClass',
+        summary="Get a list of Badges",
+        tags=['BadgeClasses']
+    )
+    def get(self, request, **kwargs):
+        pass
+
+class Issuers(EntityViewSet):
+    queryset = Issuer.objects.all()
+    serializer_class = IssuerSerializerV1
+
+class LearningPaths(EntityViewSet):
+    queryset = Issuer.objects.all()
+    serializer_class = LearningPathSerializerV1

--- a/apps/issuer/api_v3.py
+++ b/apps/issuer/api_v3.py
@@ -6,28 +6,14 @@ from django_filters import rest_framework as filters
 from apispec_drf.decorators import apispec_list_operation, apispec_post_operation, apispec_get_operation, \
     apispec_delete_operation, apispec_put_operation, apispec_operation
 
+from entity.api_v3 import EntityFilter, EntityViewSet
+
 from .serializers_v1 import BadgeClassSerializerV1, IssuerSerializerV1, LearningPathSerializerV1
 from .models import BadgeClass, Issuer, LearningPath
 
-class EntityLimitOffsetPagination(LimitOffsetPagination):
-    default_limit = 20
-
-class EntityFilter(filters.FilterSet):
-    name = filters.CharFilter(field_name='name', lookup_expr='icontains')
 
 class BadgeFilter(EntityFilter):
     tags = filters.CharFilter(field_name='badgeclasstag__name', lookup_expr='icontains')
-
-class LearningPathFilter(EntityFilter):
-    tags = filters.CharFilter(field_name='learningpathtag__name', lookup_expr='icontains')
-
-class EntityViewSet(viewsets.ModelViewSet):
-    pagination_class = EntityLimitOffsetPagination
-    http_method_names = ['get', 'head', 'options']
-    lookup_field = 'entity_id'
-    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
-    filterset_class = EntityFilter
-    ordering_fields = ['name', 'created_at']
 
 class Badges(EntityViewSet):
     queryset = BadgeClass.objects.all()
@@ -42,9 +28,14 @@ class Badges(EntityViewSet):
     def get(self, request, **kwargs):
         pass
 
+
 class Issuers(EntityViewSet):
     queryset = Issuer.objects.all()
     serializer_class = IssuerSerializerV1
+
+
+class LearningPathFilter(EntityFilter):
+    tags = filters.CharFilter(field_name='learningpathtag__name', lookup_expr='icontains')
 
 class LearningPaths(EntityViewSet):
     queryset = LearningPath.objects.all()

--- a/apps/issuer/api_v3.py
+++ b/apps/issuer/api_v3.py
@@ -9,6 +9,8 @@ from apispec_drf.decorators import apispec_list_operation, apispec_post_operatio
 from .serializers_v1 import BadgeClassSerializerV1, IssuerSerializerV1, LearningPathSerializerV1
 from .models import BadgeClass, Issuer, LearningPath
 
+class EntityLimitOffsetPagination(LimitOffsetPagination):
+    default_limit = 20
 
 class EntityFilter(filters.FilterSet):
     name = filters.CharFilter(field_name='name', lookup_expr='icontains')
@@ -20,7 +22,7 @@ class LearningPathFilter(EntityFilter):
     tags = filters.CharFilter(field_name='learningpathtag__name', lookup_expr='icontains')
 
 class EntityViewSet(viewsets.ModelViewSet):
-    pagination_class = LimitOffsetPagination
+    pagination_class = EntityLimitOffsetPagination
     http_method_names = ['get', 'head', 'options']
     lookup_field = 'entity_id'
     filter_backends = [filters.DjangoFilterBackend, OrderingFilter]

--- a/apps/issuer/permissions.py
+++ b/apps/issuer/permissions.py
@@ -41,9 +41,14 @@ def is_staff(user, issuer):
 is_on_staff = is_owner | is_staff
 is_staff_editor = is_owner | is_editor
 
-rules.add_perm('issuer.is_owner', is_owner)
-rules.add_perm('issuer.is_editor', is_staff_editor)
-rules.add_perm('issuer.is_staff', is_on_staff)
+# FIXME: should those be set here?
+try:
+    rules.add_perm('issuer.is_owner', is_owner)
+    rules.add_perm('issuer.is_editor', is_staff_editor)
+    rules.add_perm('issuer.is_staff', is_on_staff)
+except KeyError:
+    pass
+
 
 
 @rules.predicate
@@ -87,10 +92,15 @@ can_edit_badgeclass = is_badgeclass_owner | is_badgeclass_editor
 can_issue_learningpath = is_learningpath_staff  
 can_edit_learningpath = is_learningpath_owner |  is_learningpath_editor
 
-rules.add_perm('issuer.can_issue_badge', can_issue_badgeclass)
-rules.add_perm('issuer.can_edit_badgeclass', can_edit_badgeclass)
-rules.add_perm('issuer.can_issue_learningpath', can_issue_learningpath)
-rules.add_perm('issuer.can_edit_learningpath', can_edit_learningpath)
+# FIXME: should those be set here?
+try:
+    rules.add_perm('issuer.can_issue_badge', can_issue_badgeclass)
+    rules.add_perm('issuer.can_edit_badgeclass', can_edit_badgeclass)
+    rules.add_perm('issuer.can_issue_learningpath', can_issue_learningpath)
+    rules.add_perm('issuer.can_edit_learningpath', can_edit_learningpath)
+except KeyError:
+    pass
+
 
 class MayIssueLearningPath(permissions.BasePermission):
     """

--- a/apps/issuer/serializers_v3.py
+++ b/apps/issuer/serializers_v3.py
@@ -1,0 +1,107 @@
+from collections import OrderedDict
+
+from entity.serializers import DetailSerializerV2
+from issuer.models import BadgeClass
+
+
+# only for apispec for now
+
+class BadgeClassSerializerV3(DetailSerializerV2):
+
+   class Meta(DetailSerializerV2.Meta):
+      model = BadgeClass
+      apispec_definition = ('BadgeClass', {
+         'properties': OrderedDict([
+               ('entityId', {
+                  'type': "string",
+                  'format': "string",
+                  'description': "Unique identifier for this BadgeClass",
+                  'readOnly': True,
+               }),
+               ('entityType', {
+                  'type': "string",
+                  'format': "string",
+                  'description': "\"BadgeClass\"",
+                  'readOnly': True,
+               }),
+               ('openBadgeId', {
+                  'type': "string",
+                  'format': "url",
+                  'description': "URL of the OpenBadge compliant json",
+                  'readOnly': True,
+               }),
+               ('createdAt', {
+                  'type': 'string',
+                  'format': 'ISO8601 timestamp',
+                  'description': "Timestamp when the BadgeClass was created",
+                  'readOnly': True,
+               }),
+               ('createdBy', {
+                  'type': 'string',
+                  'format': 'entityId',
+                  'description': "BadgeUser who created this BadgeClass",
+                  'readOnly': True,
+               }),
+
+               ('issuer', {
+                  'type': 'string',
+                  'format': 'entityId',
+                  'description': "entityId of the Issuer who owns the BadgeClass",
+                  'required': False,
+               }),
+
+               ('name', {
+                  'type': "string",
+                  'format': "string",
+                  'description': "Name of the BadgeClass",
+                  'required': True,
+               }),
+               ('description', {
+                  'type': "string",
+                  'format': "string",
+                  'description': "Short description of the BadgeClass",
+                  'required': True,
+               }),
+               ('image', {
+                  'type': "string",
+                  'format': "data:image/png;base64",
+                  'description': "Base64 encoded string of an image that represents the BadgeClass.",
+                  'required': False,
+               }),
+               ('criteriaUrl', {
+                  'type': "string",
+                  'format': "url",
+                  'description': ("External URL that describes in a human-readable "
+                     "format the criteria for the BadgeClass"),
+                  'required': False,
+               }),
+               ('criteriaNarrative', {
+                  'type': "string",
+                  'format': "markdown",
+                  'description': "Markdown formatted description of the criteria",
+                  'required': False,
+               }),
+               ('tags', {
+                  'type': "array",
+                  'items': {
+                     'type': "string",
+                     'format': "string"
+                  },
+                  'description': "List of tags that describe the BadgeClass",
+                  'required': False,
+               }),
+               ('alignments', {
+                  'type': "array",
+                  'items': {
+                     '$ref': '#/definitions/BadgeClassAlignment'
+                  },
+                  'description': "List of objects describing objectives or educational standards",
+                  'required': False,
+               }),
+               ('expires', {
+                  '$ref': "#/definitions/BadgeClassExpiration",
+                  'description': "Expiration period for Assertions awarded from this BadgeClass",
+                  'required': False,
+               }),
+         ])
+      })

--- a/apps/issuer/v3_api_urls.py
+++ b/apps/issuer/v3_api_urls.py
@@ -1,0 +1,15 @@
+from django.conf.urls import url
+from django.urls import include, path
+from django.views.decorators.clickjacking import xframe_options_exempt
+from rest_framework import routers
+
+from . import api_v3
+
+router = routers.DefaultRouter()
+router.register(r'badge', api_v3.Badges)
+router.register(r'issuer', api_v3.Issuers)
+router.register(r'learningpath', api_v3.LearningPaths)
+
+urlpatterns = [
+	path('', include(router.urls)),
+]

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -376,7 +376,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
     'DEFAULT_VERSION': 'v1',
-    'ALLOWED_VERSIONS': ['v1', 'v2', 'bcv1', 'rfc7591'],
+    'ALLOWED_VERSIONS': ['v1', 'v2', 'v3', 'bcv1', 'rfc7591'],
     'EXCEPTION_HANDLER': 'entity.views.exception_handler',
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 100,

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -63,6 +63,8 @@ INSTALLED_APPS = [
 
     # deprecated
     'composition',
+
+    'django_filters'
 ]
 
 MIDDLEWARE = [

--- a/apps/mainsite/static/swagger-ui/API_DESCRIPTION_v3.md
+++ b/apps/mainsite/static/swagger-ui/API_DESCRIPTION_v3.md
@@ -1,0 +1,63 @@
+## Authentication
+
+Authenticate requests by including an Authorization header of type "Bearer".  For example:
+
+```bash
+curl 'https://api.badgr.io/v1/user/profile' -H "Authorization: Bearer YOURACCESSTOKEN"
+```
+
+Alternatively you can also pass the token as cookie, to utilize `HttpOnly`  cookies.
+To do this, set `withCredentials: true` in your request.
+The cookie in your request would then look something like this:
+```yaml
+Cookie: csrftoken=YOUR_CSRF_TOKEN; access_token=YOUR_ACCESS_TOKEN
+```
+
+## Access Tokens
+
+If you want to make requests to our API, you need to obtain an **Access token**.
+These are tokens with a limited time of life (24 hours by default). To request tokens, you need to make a POST request to our API.
+For security reasons in our application we store the access token in an [HttpOnly](https://owasp.org/www-community/HttpOnly) cookie.
+That means that the browser cannot access the content, instead it's passed with the requests as a cookie.
+Nevertheless we also return the access token in the data section of the response, in addition to the cookie section.
+
+If you use `cURL` for example this might look like this:
+```bash
+curl --request POST \
+    --url 'https://api.openbadges.education/o/token' \
+    --header 'content-type: application/x-www-form-urlencoded' \
+    --data 'grant_type=password' \
+    --data 'username=YOUR_USERNAME' \
+    --data 'password=YOUR_PASSWORD' \
+    --data 'client_id=public' --verbose
+```
+
+Or with client ID and secret:
+```bash
+curl --request POST \
+    --url 'https://api.openbadges.education/o/token' \
+    --header 'content-type: application/x-www-form-urlencoded' \
+    --data 'grant_type=client_credentials' \
+    --data 'client_id=YOUR_CLIENT_ID' \
+    --data 'client_secret=YOUR_CLIENT_SECRET' --verbose
+```
+
+The response will then look something like this:
+```text
+<a lot of verbose messages that aren't relevant>
+< Set-Cookie:  access_token=YOUR_ACCESS_TOKEN; expires=Tue, 19 Nov 2024 13:19:00 GMT; HttpOnly; Max-Age=86400; Path=/; Secure
+< Set-Cookie:  refresh_token=YOUR_REFRESH_TOKEN; expires=Wed, 19 Nov 2024 13:19:00 GMT; HttpOnly; Max-Age=86400; Path=/
+< 
+* Connection #0 to host api.openbadges.education left intact
+{"access_token": "YOUR_ACCESS_TOKEN", "expires_in": 86400, "token_type": "Bearer", "scope": "r:profile", "refresh_token": "YOUR_REFRESH_TOKEN"}
+```
+Once again, note that the scope doesn't actually mean anything (yet).
+
+## Token Expiration
+Access tokens will expire, if an expired token is used a 403 status code will be returned.
+
+The refresh token can be used to automatically renew an access token without requiring the password again.  For example:
+
+```bash
+curl -X POST 'https://api.badgr.io/o/token' -d "grant_type=refresh_token&refresh_token=YOURREFRESHTOKEN"
+```

--- a/apps/mainsite/urls.py
+++ b/apps/mainsite/urls.py
@@ -181,6 +181,8 @@ urlpatterns = [
   
     url(r'^badgeRequests/(?P<badgeSlug>[^/]+)$', badgeRequestsByBadgeClass, name="badge-requests-by-badgeclass"),
 
+    url(r"^v3/", include("issuer.v3_api_urls"), kwargs={"version": "v3"}),
+
 
     # meinBildungsraum OIDC connection
     path('oidc/', include('mozilla_django_oidc.urls')),

--- a/apps/mainsite/urls.py
+++ b/apps/mainsite/urls.py
@@ -182,6 +182,7 @@ urlpatterns = [
     url(r'^badgeRequests/(?P<badgeSlug>[^/]+)$', badgeRequestsByBadgeClass, name="badge-requests-by-badgeclass"),
 
     url(r"^v3/", include("issuer.v3_api_urls"), kwargs={"version": "v3"}),
+    url(r"^v3/backpack/", include("backpack.v3_api_urls"), kwargs={"version": "v3"}),
 
 
     # meinBildungsraum OIDC connection

--- a/requirements.txt
+++ b/requirements.txt
@@ -126,3 +126,5 @@ svglib
 qrcode
 
 django-dbbackup
+
+django-filter==2.4.0


### PR DESCRIPTION
This lays the foundation for a new v3 API structure with server side pagination, filtering and sorting.

example issuer call, offset 20 (page 2, limit 20 is default)
`/v3/issuers/?offset=20`

example learningpath call, limit 5 results and filtering on tag 'coffee'
`/v3/learningpaths/?limit=5&tags=coffee`

example badgeclass call, filtering on two tags and sorting by creation date
`/v3/badges/?tags=test&tags=participation&ordering=created_at`

example single entity call
`/v3/badges/iH5yR5XaTdKOCJtDQwjMIg/`

For now, this adds the previous "public" endpoints for reading issuers, badgeclasses and learningpaths and permission restricted backpack endpoints for badgeinstances and learningpaths.
Existing v1 serializers are being used for now but should be reworked later on.