### PR TITLE
Apply fix for ulimits on some Linux distros

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -45,6 +45,13 @@ services:
       - "MYSQL_PASSWORD=password"
       - "MYSQL_HOST=db"
       - "MYSQL_ROOT_PASSWORD=password"
+    ulimits:
+      # Needs to be set e.g. on Fedora, Arch, etc.
+      # https://github.com/docker-library/mysql/issues/873#issuecomment-1909948195
+      # https://github.com/ddev/ddev/issues/4862#issuecomment-1533141193
+      nofile: # Fix memory leak issue on some systems when LimitCORE=infinity or LimitNOFILE=infinity (containerd)
+        soft: 1048576
+        hard: 1048576
     expose:
       - "3306"
     networks:
@@ -54,7 +61,7 @@ services:
     container_name: mailhog
     restart: always
     ports:
-      - "1025:1025" #127.0.0.1:1025:1025  
+      - "1025:1025" #127.0.0.1:1025:1025
       - "8025:8025"
     networks:
       - badgr

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,6 +49,13 @@ services:
       - "MYSQL_PASSWORD=password"
       - "MYSQL_HOST=db"
       - "MYSQL_ROOT_PASSWORD=password"
+    ulimits:
+      # Needs to be set e.g. on Fedora, Arch, etc.
+      # https://github.com/docker-library/mysql/issues/873#issuecomment-1909948195
+      # https://github.com/ddev/ddev/issues/4862#issuecomment-1533141193
+      nofile: # Fix memory leak issue on some systems when LimitCORE=infinity or LimitNOFILE=infinity (containerd)
+        soft: 1048576
+        hard: 1048576
     expose:
       - "3306"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,13 @@ services:
       - "MYSQL_PASSWORD=password"
       - "MYSQL_HOST=db"
       - "MYSQL_ROOT_PASSWORD=password"
+    ulimits:
+      # Needs to be set e.g. on Fedora, Arch, etc.
+      # https://github.com/docker-library/mysql/issues/873#issuecomment-1909948195
+      # https://github.com/ddev/ddev/issues/4862#issuecomment-1533141193
+      nofile: # Fix memory leak issue on some systems when LimitCORE=infinity or LimitNOFILE=infinity (containerd)
+        soft: 1048576
+        hard: 1048576
     expose:
       - "3306"
     networks:


### PR DESCRIPTION
Hey, new here :wave: 
I followed the README for setting up my dev environment on my Fedora installation.
After running `docker compose up` the database container would fail to launch with the really helpful error message: "image failed while attempting to check config".

It turns out to be an os-specific setting for the limitations of containers in the daemon.
Specifically `nofile` and `core` which some distros set to infinity.
Overriding this with the corresponding settings for the MySQL container fixes the issue. This does seem to be an issue with only mysql.

Since [this comment](https://github.com/docker-library/mysql/issues/873#issuecomment-1909948195) states that this may become an issue on newer versions of Ubuntu server, we thought about adding this to the production and staging environments as a precaution.
@jona159 asked me to involve @timber-they for an opinion. What do you think?
Any input on the limits set? (They do seem a bit high don't they?)
We will try and deploy this to the develop environment and observe the resource utilization via the grafana dashboard to see if anything noticable is happening.