### PR TITLE
fix: only update if it badgeinstance already exists

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -1775,7 +1775,8 @@ class BadgeInstance(BaseAuditedModel, BaseVersionedEntity, BaseOpenBadgeObjectMo
 
             if not self.ob_json_2_0 or force_recreate:
                 self.ob_json_2_0 = json_dumps(self.get_json_2_0())
-                self.save(update_fields=['ob_json_2_0'])
+                if self.pk:
+                    self.save(update_fields=['ob_json_2_0'])
 
             json = json_loads(self.ob_json_2_0, object_pairs_hook=OrderedDict)
 


### PR DESCRIPTION
Fixes an error when awarding a badge: 
```
Internal Server Error: /v1/issuer/issuers/oiGGzC92R_ChlvBpTCm9bA/badges/sJb29mt0RR2XE-cvJu08_Q/assertions
2025-04-24 08:58:16 Traceback (most recent call last):
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
2025-04-24 08:58:16     response = get_response(request)
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
2025-04-24 08:58:16     response = wrapped_callback(request, *callback_args, **callback_kwargs)
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
2025-04-24 08:58:16     return view_func(*args, **kwargs)
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/django/views/generic/base.py", line 70, in view
2025-04-24 08:58:16     return self.dispatch(request, *args, **kwargs)
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
2025-04-24 08:58:16     response = self.handle_exception(exc)
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
2025-04-24 08:58:16     self.raise_uncaught_exception(exc)
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
2025-04-24 08:58:16     raise exc
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
2025-04-24 08:58:16     response = handler(request, *args, **kwargs)
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/apispec_drf/decorators.py", line 154, in wrapper
2025-04-24 08:58:16     return wrapped(*args, **kwargs)
2025-04-24 08:58:16   File "/badgr_server/apps/issuer/api.py", line 664, in post
2025-04-24 08:58:16     return super(BadgeInstanceList, self).post(request, **kwargs)
2025-04-24 08:58:16   File "/badgr_server/apps/entity/api.py", line 87, in post
2025-04-24 08:58:16     new_instance = serializer.save(created_by=request.user)
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/rest_framework/serializers.py", line 205, in save
2025-04-24 08:58:16     self.instance = self.create(validated_data)
2025-04-24 08:58:16   File "/badgr_server/apps/issuer/serializers_v1.py", line 716, in create
2025-04-24 08:58:16     return self.context.get("badgeclass").issue(
2025-04-24 08:58:16   File "/badgr_server/apps/issuer/models.py", line 1110, in issue
2025-04-24 08:58:16     return BadgeInstance.objects.create(
2025-04-24 08:58:16   File "/badgr_server/apps/issuer/managers.py", line 325, in create
2025-04-24 08:58:16     new_instance.save()
2025-04-24 08:58:16   File "/badgr_server/apps/issuer/models.py", line 1510, in save
2025-04-24 08:58:16     self.get_json(obi_version=UNVERSIONED_BAKED_VERSION), indent=2
2025-04-24 08:58:16   File "/badgr_server/apps/issuer/models.py", line 1794, in get_json
2025-04-24 08:58:16     self.save(update_fields=['ob_json_2_0'])
2025-04-24 08:58:16   File "/badgr_server/apps/issuer/models.py", line 1538, in save
2025-04-24 08:58:16     super(BadgeInstance, self).save(*args, **kwargs)
2025-04-24 08:58:16   File "/badgr_server/apps/entity/models.py", line 26, in save
2025-04-24 08:58:16     return super(_AbstractVersionedEntity, self).save(*args, **kwargs)
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/cachemodel/models.py", line 39, in save
2025-04-24 08:58:16     super(CacheModel, self).save(*args, **kwargs)
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/django/db/models/base.py", line 726, in save
2025-04-24 08:58:16     self.save_base(using=using, force_insert=force_insert,
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/django/db/models/base.py", line 763, in save_base
2025-04-24 08:58:16     updated = self._save_table(
2025-04-24 08:58:16   File "/usr/local/lib/python3.8/site-packages/django/db/models/base.py", line 828, in _save_table
2025-04-24 08:58:16     raise ValueError("Cannot force an update in save() with no primary key.")
2025-04-24 08:58:16 ValueError: Cannot force an update in save() with no primary key.
```