### PR TITLE
fix: restart redis when container exits

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,7 +1,6 @@
 # A dockerized badgr-server stack to emulate a production build
 version: "3.9"
 services:
-
   change-ownership:
     image: alpine
     user: root
@@ -102,6 +101,7 @@ services:
 
   redis:
     image: redis:latest
+    restart: unless-stopped
     networks:
       - badgr
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
 
   redis:
     image: redis:latest
+    restart: unless-stopped
     networks:
       - badgr
 


### PR DESCRIPTION
```restart: unless-stopped``` is already set on the remote servers