### PR TITLE
fix(issuer): apply network overlay when regenerating badge image on edit

### DIFF
--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -709,8 +709,17 @@ class BadgeClassSerializerV1(
                     org_img_ext = extensions.get(name="extensions:OrgImageExtension")
                     original_image = json.loads(org_img_ext.original_json)["OrgImage"]
 
+                    issuer_image = None
+                    network_image = None
+
+                    if not (instance.issuer.is_network and category == "learningpath"):
+                        if instance.issuer.is_network:
+                            network_image = instance.issuer.image
+                        else:
+                            issuer_image = instance.issuer.image
+
                     instance.generate_badge_image(
-                        category, original_image, instance.issuer.image
+                        category, original_image, issuer_image, network_image
                     )
                     instance.save()
                 except BadgeClassExtension.DoesNotExist as e:


### PR DESCRIPTION
[Issue #2020](https://github.com/open-educational-badges/badgr-ui/issues/2020)

Overview of changes: 

- Badge image update was always passing issuer.image as issuer_image, causing the same institution overlay to be applied for network badges as well
- Implement the same overlay image logic as badge creation: pass network_image for network issuers and issuer_image for institution issuers

See also: [badgr-ui changes](https://github.com/open-educational-badges/badgr-ui/pull/2024)