### PR TITLE
fix(batch): restore serializer class path for QR code batch assertions

### DIFF
--- a/apps/issuer/api.py
+++ b/apps/issuer/api.py
@@ -1,5 +1,6 @@
 import datetime
 from collections import defaultdict
+import importlib
 import json
 
 import dateutil.parser
@@ -724,86 +725,85 @@ class BadgeClassDetail(BaseEntityDetailView):
     def put(self, request, **kwargs):
         return super(BadgeClassDetail, self).put(request, **kwargs)
 
-class BadgeInstancesBatchAssertionTask:
-    def process_batch_assertions(
-        self,
-        assertions,
-        user_id,
-        badgeclass_id,
-        issuerSlug,
-        create_notification=False,
-    ):
-        try:
-            User = get_user_model()
-            user = User.objects.get(id=user_id)
-            badgeclass = BadgeClass.objects.get(id=badgeclass_id)
-
-            total = len(assertions)
-
-            processed = 0
-            successful = []
-            errors = []
-
-            for assertion in assertions:
-                request_entity_id = assertion.get("request_entity_id")
-                assertion["create_notification"] = create_notification
-
-                serializer = BadgeInstanceSerializerV1(
-                    data=assertion,
-                    context={
-                        "badgeclass": badgeclass,
-                        "user": user,
-                        "issuerSlug": issuerSlug,
-                    },
-                )
-
-                if serializer.is_valid():
-                    try:
-                        instance = serializer.save(created_by=user)
-                        successful.append(
-                            {
-                                "badge_instance": BadgeInstanceSerializerV1(instance).data,
-                                "request_entity_id": request_entity_id,
-                            }
-                        )
-                    except Exception as e:
-                        errors.append({"assertion": assertion, "error": str(e)})
-                else:
-                    errors.append({"assertion": assertion, "error": serializer.errors})
-
-                processed += 1
-
-                # Emit progress after each iteration
-                self.update_state(
-                    state="PROGRESS",
-                    meta={
-                        "processed": processed,
-                        "total": total,
-                        "data": successful,
-                        "errors": errors,
-                    },
-                )
-
-            return {
-                "success": len(errors) == 0,
-                "status": status.HTTP_201_CREATED
-                if len(errors) == 0
-                else status.HTTP_207_MULTI_STATUS,
-                "data": successful,
-                "errors": errors,
-            }
-
-        except Exception as e:
-            return {
-                "success": False,
-                "status": status.HTTP_500_INTERNAL_SERVER_ERROR,
-                "error": str(e),
-            }
-
-
 @shared_task(bind=True)
-def process_batch_assertions(*args, **kwargs):
-    BadgeInstancesBatchAssertionTask.process_batch_assertions(*args, **kwargs)
+def process_batch_assertions(
+    self,
+    assertions,
+    user_id,
+    badgeclass_id,
+    issuerSlug,
+    serializer_class_path=None,
+    create_notification=False,
+):
+    if serializer_class_path:
+        module_path, class_name = serializer_class_path.rsplit(".", 1)
+        serializer_class = getattr(importlib.import_module(module_path), class_name)
+    else:
+        from issuer.serializers_v1 import BadgeInstanceSerializerV1
+        serializer_class = BadgeInstanceSerializerV1
+
+    try:
+        User = get_user_model()
+        user = User.objects.get(id=user_id)
+        badgeclass = BadgeClass.objects.get(id=badgeclass_id)
+
+        total = len(assertions)
+        processed = 0
+        successful = []
+        errors = []
+
+        for assertion in assertions:
+            request_entity_id = assertion.get("request_entity_id")
+            assertion["create_notification"] = create_notification
+
+            serializer = serializer_class(
+                data=assertion,
+                context={
+                    "badgeclass": badgeclass,
+                    "user": user,
+                    "issuerSlug": issuerSlug,
+                },
+            )
+
+            if serializer.is_valid():
+                try:
+                    instance = serializer.save(created_by=user)
+                    successful.append(
+                        {
+                            "badge_instance": serializer_class(instance).data,
+                            "request_entity_id": request_entity_id,
+                        }
+                    )
+                except Exception as e:
+                    errors.append({"assertion": assertion, "error": str(e)})
+            else:
+                errors.append({"assertion": assertion, "error": serializer.errors})
+
+            processed += 1
+            self.update_state(
+                state="PROGRESS",
+                meta={
+                    "processed": processed,
+                    "total": total,
+                    "data": successful,
+                    "errors": errors,
+                },
+            )
+
+        return {
+            "success": len(errors) == 0,
+            "status": status.HTTP_201_CREATED if len(errors) == 0 else status.HTTP_207_MULTI_STATUS,
+            "data": successful,
+            "errors": errors,
+        }
+
+    except Exception as e:
+        return {
+            "success": False,
+            "status": status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "error": str(e),
+        }
+
 
 class BatchAssertionsIssue(VersionedObjectMixin, BaseEntityView):
     model = BadgeClass  # used by .get_object()
@@ -879,11 +879,15 @@ class BatchAssertionsIssue(VersionedObjectMixin, BaseEntityView):
             raise BadgrQuotaExceededException
 
         # Start async task
+        sc = self.v1_serializer_class
+        serializer_class_path = f"{sc.__module__}.{sc.__qualname__}"
+
         task = process_batch_assertions.delay(
             assertions=assertions,
             user_id=request.user.id,
             badgeclass_id=badgeclass.id,
             issuerSlug=issuerSlug,
+            serializer_class_path=serializer_class_path,
             create_notification=create_notification,
         )
 


### PR DESCRIPTION
Replace the broken class wrapper with a single clean @shared_task that accepts serializer_class_path as a JSON-serializable string, imports the correct class inside the worker, and falls back to BadgeInstanceSerializerV1 if no path is given.