### PR TITLE
fix: extend is_learningpath_staff permissions

### DIFF
--- a/apps/issuer/permissions.py
+++ b/apps/issuer/permissions.py
@@ -154,10 +154,12 @@ def is_partner_issuer_staff(user, badgeclass):
 
 @rules.predicate
 def is_learningpath_staff(user, learningpath):
-    return any(
-        staff.user_id == user.id
-        for staff in learningpath.cached_issuer.cached_issuerstaff()
-    )
+    issuer = learningpath.cached_issuer
+    if any(staff.user_id == user.id for staff in issuer.cached_issuerstaff()):
+        return True
+    if issuer.is_network:
+        return is_network_member(user, issuer)
+    return False
 
 
 @rules.predicate


### PR DESCRIPTION
Fix 404 error for partner issuer staff being unable to access network-owned learning paths. Approach: extended `is_learningpath_staff` to check network membership via the existing `is_network_member` predicate instead of only checking direct network staff.
