### PR TITLE
fix(badge-upload): add support for new iTXt keyword openbadges

### DIFF
--- a/apps/issuer/helpers.py
+++ b/apps/issuer/helpers.py
@@ -255,20 +255,64 @@ class ImportedBadgeHelper:
                 except (TypeError, ValueError):
                     raise ValidationError("Could not parse dict to json")
 
+            if hasattr(query, "seek"):
+                query.seek(0)
+
             # use openbadges library to parse json from images
             verifier_store = openbadges.load_store(
                 query,
                 recipient_profile=badgecheck_recipient_profile,
                 **cls.badgecheck_options(),
             )
-            query_json = verifier_store.get_state()["input"]["value"]
-            verifier_input = json.loads(query_json)
+            store_state = verifier_store.get_state()
 
-            # TODO: ob3 as JWT
-            # try:
-            #     verifier_input = verifier_input['vc']
-            # except:
-            #     pass
+            # Surface errors from store init (e.g. PNG with no embedded OB metadata)
+            failed_tasks = [
+                t for t in store_state.get("tasks", []) if t.get("success") is False
+            ]
+            if failed_tasks:
+                raise ValidationError(
+                    [
+                        {
+                            "name": "INVALID_BADGE",
+                            "description": failed_tasks[0].get(
+                                "result", "Unable to read badge metadata from file"
+                            ),
+                        }
+                    ]
+                )
+
+            query_json = store_state["input"]["value"]
+
+            if isinstance(query_json, bytes):
+                query_json = query_json.decode("utf-8")
+
+            # If unbaked data is a URL, fetch content manually to bypass
+            if isinstance(query_json, str) and query_json.startswith("http"):
+                try:
+                    r = requests.get(
+                        query_json,
+                        headers={"Accept": "application/ld+json, application/json"},
+                        timeout=10,
+                    )
+                    if r.status_code == 200:
+                        query_json = r.text
+                except Exception:
+                    pass
+
+            # Normalize once: downstream code always receives a dict
+            if isinstance(query_json, dict):
+                verifier_input = query_json
+            elif isinstance(query_json, (str, bytes, bytearray)):
+                try:
+                    verifier_input = json.loads(query_json)
+                except (ValueError, TypeError):
+                    verifier_input = None
+            else:
+                verifier_input = None
+
+            if verifier_input is None:
+                raise ValueError(f"Invalid badge input type: {type(query_json)}")
 
             is_v3 = assertion_is_v3(verifier_input)
 
@@ -277,9 +321,31 @@ class ImportedBadgeHelper:
                 response = cls.validate_v3(verifier_input, badgecheck_recipient_profile)
 
             else:
+                # Check if the user is mistakenly uploading a BadgeClass definition
+                badge_type = verifier_input.get("type")
+                if badge_type == "BadgeClass" or (
+                    isinstance(badge_type, list) and "BadgeClass" in badge_type
+                ):
+                    raise ValidationError(
+                        [
+                            {
+                                "name": "INVALID_INPUT_TYPE",
+                                "description": "This file contains a Badge Class definition. Please upload an awarded Badge Assertion instead.",
+                            }
+                        ]
+                    )
+
                 # ob2 validation through openbadges library
+                # openbadges.verify() expects a URL, JSON string, or file — not a dict.
+                # Pass the original URL when available (avoids double-fetch); otherwise
+                # serialise the dict back to a JSON string.
+                if isinstance(query, str) and query.startswith("http"):
+                    verify_input = query
+                else:
+                    verify_input = json.dumps(verifier_input)
+
                 response = openbadges.verify(
-                    query,
+                    verify_input,
                     recipient_profile=badgecheck_recipient_profile,
                     **cls.badgecheck_options(),
                 )

--- a/openbadges/verifier/verifier.py
+++ b/openbadges/verifier/verifier.py
@@ -9,21 +9,26 @@ from .exceptions import SkipTask, TaskPrerequisitesError
 from .logger import logger
 from .openbadges_context import OPENBADGES_CONTEXT_V2_URI
 from .reducers import main_reducer
-from .state import (filter_active_tasks, filter_messages_for_report, format_message,
-                    INITIAL_STATE, MESSAGE_LEVEL_ERROR, MESSAGE_LEVEL_WARNING,)
+from .state import (
+    filter_active_tasks,
+    filter_messages_for_report,
+    format_message,
+    INITIAL_STATE,
+    MESSAGE_LEVEL_ERROR,
+    MESSAGE_LEVEL_WARNING,
+)
 from . import tasks
-from .tasks.task_types import INTAKE_JSON, JSONLD_COMPACT_DATA, VALIDATE_EXTENSION_NODE
+from .tasks.task_types import JSONLD_COMPACT_DATA, VALIDATE_EXTENSION_NODE
 from .tasks.validation import OBClasses
 from .utils import list_of, CachableDocumentLoader, jsonld_use_cache
 
 
-
 DEFAULT_OPTIONS = {
-    'include_original_json': False,  # Return the original JSON strings fetched from HTTP
-    'use_cache': True,
-    'cache_backend': 'memory',
-    'cache_expire_after': 300,
-    'jsonld_options': jsonld_use_cache
+    "include_original_json": False,  # Return the original JSON strings fetched from HTTP
+    "use_cache": True,
+    "cache_backend": "memory",
+    "cache_expire_after": 300,
+    "jsonld_options": jsonld_use_cache,
 }
 
 
@@ -34,16 +39,16 @@ def _get_options(options):
     else:
         selected = DEFAULT_OPTIONS
 
-    if selected['use_cache']:
+    if selected["use_cache"]:
         doc_loader = CachableDocumentLoader(
-            use_cache=selected['use_cache'],
-            backend=selected['cache_backend'],
-            expire_after=selected['cache_expire_after']
+            use_cache=selected["use_cache"],
+            backend=selected["cache_backend"],
+            expire_after=selected["cache_expire_after"],
         )
     else:
         doc_loader = CachableDocumentLoader(use_cache=False)
 
-    selected['jsonld_options'] = {'documentLoader': doc_loader}
+    selected["jsonld_options"] = {"documentLoader": doc_loader}
     return selected
 
 
@@ -60,63 +65,86 @@ def call_task(task_func, task_meta, store, options=DEFAULT_OPTIONS):
     try:
         success, message, actions = task_func(store.get_state(), task_meta, **options)
     except SkipTask:
-        raise NotImplemented("Implement SkipTask handling in call_task")
+        raise NotImplementedError("Implement SkipTask handling in call_task")
     except TaskPrerequisitesError:
         message = "Task could not run due to unmet prerequisites."
-        store.dispatch(resolve_task(task_meta.get('task_id'), success=False, result=message))
+        store.dispatch(
+            resolve_task(task_meta.get("task_id"), success=False, result=message)
+        )
     except Exception as e:
         error_message = traceback.format_exception_only(type(e), e)
         logger.error(traceback.format_exc())
         message = "{} {}".format(e.__class__, error_message)
-        store.dispatch(resolve_task(task_meta.get('task_id'), success=False, result=message))
+        store.dispatch(
+            resolve_task(task_meta.get("task_id"), success=False, result=message)
+        )
     else:
-        store.dispatch(resolve_task(task_meta.get('task_id'), success=success, result=message))
+        store.dispatch(
+            resolve_task(task_meta.get("task_id"), success=success, result=message)
+        )
         if success:
-            for trigger in list_of(task_meta.get('triggers_completion', [])):
-                store.dispatch(trigger_condition(trigger, 'Completed by {}: {}'.format(
-                    task_meta.get('task_id'), task_meta.get('name')
-                )))
+            for trigger in list_of(task_meta.get("triggers_completion", [])):
+                store.dispatch(
+                    trigger_condition(
+                        trigger,
+                        "Completed by {}: {}".format(
+                            task_meta.get("task_id"), task_meta.get("name")
+                        ),
+                    )
+                )
 
     # Make updates and queue up next tasks.
     for action in actions:
         if not isinstance(action, dict):
-            raise TypeError("Task {} returned actions of an unreadable type. Task details: {}".format(
-                task_meta.get('name'), json.dumps(task_meta)
-            ))
+            raise TypeError(
+                "Task {} returned actions of an unreadable type. Task details: {}".format(
+                    task_meta.get("name"), json.dumps(task_meta)
+                )
+            )
         store.dispatch(action)
 
 
-def verification_store(badge_input, recipient_profile=None, store=None, options=DEFAULT_OPTIONS, run_tasks=True):
+def verification_store(
+    badge_input,
+    recipient_profile=None,
+    store=None,
+    options=DEFAULT_OPTIONS,
+    run_tasks=True,
+):
     if store is None:
         store = create_store(main_reducer, INITIAL_STATE)
     try:
-        if hasattr(badge_input, 'read') and hasattr(badge_input, 'seek'):
+        if hasattr(badge_input, "read") and hasattr(badge_input, "seek"):
             badge_input.seek(0)
             badge_data = unbake(badge_input)
-            if not badge_data:
-                raise ValueError("Could not find Open Badges metadata in file.")
+            if badge_data is None:
+                raise ValueError(
+                    "No Open Badges metadata found in PNG. Provide assertion URL or JSON instead."
+                )
         else:
             badge_data = badge_input
     except ValueError as e:
-        # Could not obtain badge data from input. Set the result as a failed DETECT_INPUT_TYPE task.
-        store.dispatch(store_input(badge_input.name))
+        store.dispatch(store_input(getattr(badge_input, "name", str(badge_input))))
         store.dispatch(add_task(tasks.DETECT_INPUT_TYPE))
-        store.dispatch(set_input_type('file'))
-        task = store.get_state()['tasks'][0]
-        store.dispatch(resolve_task(task.get('task_id'), success=False, result=e.message))
+        store.dispatch(set_input_type("file"))
+        task = store.get_state()["tasks"][0]
+        store.dispatch(resolve_task(task.get("task_id"), success=False, result=str(e)))
     else:
         store.dispatch(store_input(badge_data))
         store.dispatch(add_task(tasks.DETECT_INPUT_TYPE))
 
     if recipient_profile:
-        profile_id = recipient_profile.get('id')
-        recipient_profile['@context'] = recipient_profile.get('@context', OPENBADGES_CONTEXT_V2_URI)
+        profile_id = recipient_profile.get("id")
+        recipient_profile["@context"] = recipient_profile.get(
+            "@context", OPENBADGES_CONTEXT_V2_URI
+        )
         task = add_task(
             JSONLD_COMPACT_DATA,
             data=json.dumps(recipient_profile),
-            expected_class=OBClasses.ExpectedRecipientProfile)
+            expected_class=OBClasses.ExpectedRecipientProfile,
+        )
         if profile_id:
-            task['node_id'] = profile_id
+            task["node_id"] = profile_id
         store.dispatch(task)
 
     if run_tasks:
@@ -124,12 +152,12 @@ def verification_store(badge_input, recipient_profile=None, store=None, options=
         while len(filter_active_tasks(store.get_state())):
             active_tasks = filter_active_tasks(store.get_state())
             task_meta = active_tasks[0]
-            task_func = tasks.task_named(task_meta['name'])
+            task_func = tasks.task_named(task_meta["name"])
 
-            if task_meta['task_id'] == last_task_id:
+            if task_meta["task_id"] == last_task_id:
                 break
 
-            last_task_id = task_meta['task_id']
+            last_task_id = task_meta["task_id"]
             call_task(task_func, task_meta, store, options)
 
     return store
@@ -141,38 +169,42 @@ def generate_report(store, options=DEFAULT_OPTIONS):
     """
     state = store.get_state()
 
-    processed_input = state['input'].copy()
-    if not options.get('include_original_json'):
+    processed_input = state["input"].copy()
+    if not options.get("include_original_json"):
         try:
-            del processed_input['original_json']
+            del processed_input["original_json"]
         except KeyError:
             pass
 
     tasks_for_messages_list = filter_messages_for_report(state)
-    report = state['report'].copy()
-    report['messages'] = []
+    report = state["report"].copy()
+    report["messages"] = []
     for task in tasks_for_messages_list:
-        report['messages'].append(format_message(task))
+        report["messages"].append(format_message(task))
 
-    report['errorCount'] = len([m for m in report['messages'] if m['messageLevel'] == MESSAGE_LEVEL_ERROR])
-    report['warningCount'] = len([m for m in report['messages'] if m['messageLevel'] == MESSAGE_LEVEL_WARNING])
+    report["errorCount"] = len(
+        [m for m in report["messages"] if m["messageLevel"] == MESSAGE_LEVEL_ERROR]
+    )
+    report["warningCount"] = len(
+        [m for m in report["messages"] if m["messageLevel"] == MESSAGE_LEVEL_WARNING]
+    )
 
     is_valid = True  # Assume to be true at first
-    if bool(report['errorCount']) or len(state.get('graph', [])) == 0:
+    if bool(report["errorCount"]) or len(state.get("graph", [])) == 0:
         is_valid = False
-    report['valid'] = is_valid
+    report["valid"] = is_valid
 
-    ret = {
-        'graph': state['graph'],
-        'input': processed_input,
-        'report': report
-    }
+    ret = {"graph": state["graph"], "input": processed_input, "report": report}
     return ret
+
 
 def load_store(badge_input, recipient_profile=None, **options):
     selected_options = _get_options(options)
-    store = verification_store(badge_input, recipient_profile, options=selected_options, run_tasks=False)
+    store = verification_store(
+        badge_input, recipient_profile, options=selected_options, run_tasks=False
+    )
     return store
+
 
 def verify(badge_input, recipient_profile=None, **options):
     """
@@ -196,9 +228,15 @@ def extension_validation_store(extension_input, store=None, options=DEFAULT_OPTI
 
     store.dispatch(store_input(extension_input.copy()))
 
-    extension_input['@context'] = extension_input.get('@context', OPENBADGES_CONTEXT_V2_URI)
-    extension_input['id'] = extension_input.get('id', '_:extension_validation_input')
-    compact_task = add_task(JSONLD_COMPACT_DATA, detectAndValidateClass=False, data=json.dumps(extension_input))
+    extension_input["@context"] = extension_input.get(
+        "@context", OPENBADGES_CONTEXT_V2_URI
+    )
+    extension_input["id"] = extension_input.get("id", "_:extension_validation_input")
+    compact_task = add_task(
+        JSONLD_COMPACT_DATA,
+        detectAndValidateClass=False,
+        data=json.dumps(extension_input),
+    )
     store.dispatch(compact_task)
 
     tasks_remaining = True
@@ -208,18 +246,18 @@ def extension_validation_store(extension_input, store=None, options=DEFAULT_OPTI
             tasks_remaining = False
             break
         task_meta = active_tasks[0]
-        task_func = tasks.task_named(task_meta['name'])
+        task_func = tasks.task_named(task_meta["name"])
         call_task(task_func, task_meta, store, options)
 
-
-    all_tasks = store.get_state()['tasks']
-    try:
-        first_extension_node_validation_task = [t for t in all_tasks if t['name'] == VALIDATE_EXTENSION_NODE][0]
-    except IndexError:
-        store.dispatch(report_message(
-            "No extensions were found to test. Check for proper use of context and type to declare an extension.",
-            message_level=MESSAGE_LEVEL_ERROR, success=False
-        ))
+    all_tasks = store.get_state()["tasks"]
+    if not any(t["name"] == VALIDATE_EXTENSION_NODE for t in all_tasks):
+        store.dispatch(
+            report_message(
+                "No extensions were found to test. Check for proper use of context and type to declare an extension.",
+                message_level=MESSAGE_LEVEL_ERROR,
+                success=False,
+            )
+        )
 
     return store
 

--- a/openbadges_bakery/png_bakery.py
+++ b/openbadges_bakery/png_bakery.py
@@ -1,8 +1,5 @@
 import codecs
-import hashlib
-from io import BytesIO, StringIO
 import itertools
-import os.path
 import png
 import re
 from tempfile import NamedTemporaryFile
@@ -10,16 +7,21 @@ from tempfile import NamedTemporaryFile
 
 def unbake(imageFile):
     """
-    Return the openbadgecredential content contained in a baked PNG file.
+    Return the openbadges content contained in a baked PNG file.
     If this doesn't work, return None.
 
-    If there is both an iTXt and tEXt chunk with keyword openbadgecredential,
-    the iTXt chunk content will be returned.
+    Recognises both 'openbadges' (OB2 standard, used by Moodle and modern issuers)
+    and 'openbadgecredential' (legacy keyword from older bakery implementations).
+    When both exist, the iTXt chunk takes precedence over tEXt.
     """
 
     reader = png.Reader(file=imageFile)
     for chunktype, content in reader.chunks():
-        if chunktype == b"iTXt" and content.startswith(b"openbadgecredential\x00"):
+        if chunktype == b"iTXt" and content.startswith(b"openbadges\x00"):
+            return re.sub(b"openbadges[\x00]+", b"", content).decode("utf8")
+        elif chunktype == b"tEXt" and content.startswith(b"openbadges\x00"):
+            return content.split(b"\x00")[1].decode("utf8")
+        elif chunktype == b"iTXt" and content.startswith(b"openbadgecredential\x00"):
             return re.sub(b"openbadgecredential[\x00]+", b"", content).decode("utf8")
         elif chunktype == b"tEXt" and content.startswith(b"openbadgecredential\x00"):
             return content.split(b"\x00")[1].decode("utf8")
@@ -51,7 +53,9 @@ def baked_chunks(original_chunks, badge_chunk):
     """
 
     def is_not_previous_assertion(chunk):
-        if chunk[1].startswith(b"openbadgecredential\x00"):
+        if chunk[1].startswith(b"openbadges\x00") or chunk[1].startswith(
+            b"openbadgecredential\x00"
+        ):
             return False
         return True
 


### PR DESCRIPTION
Issue [#2035](https://github.com/open-educational-badges/badgr-ui/issues/2035)

All modern OB2 issuers bake assertion data into PNG files using the iTXt chunk keyword `openbadges`. The local openbadges_bakery package only recognized the legacy `openbadgecredential` keyword, so unbake() silently returned **None** for any badge issued by Moodle or similar platforms. This caused every PNG upload from these issuers to fail.

**Root cause**
----------
openbadges_bakery/png_bakery.py was shadowing the pip-installed version of the same package. The pip version correctly handles the `openbadges` keyword; the local copy was never updated to match.

**Summary of Changes**
-------
openbadges_bakery/png_bakery.py:
- unbake() now checks for the `openbadges\x00` iTXt/tEXt keyword first (OB2 standard), then falls back to `openbadgecredential\x00` (legacy), so both old and new baked badges are handled.
- baked_chunks() filters both keywords when stripping a previous assertion before re-baking.

openbadges/verifier/verifier.py
- Fixed `if not badge_data:` → `if badge_data is None:` to avoid a false positive on empty-string output.
- Fixed `badge_input.name` → `getattr(badge_input, "name", str(badge_input))` to avoid AttributeError when the input is a URL string, not a file.
- Replaced `e.message` → `str(e)` (Python 3 exceptions have no .message attr).

apps/issuer/helpers.py (ImportedBadgeHelper only)
- Seek the file back to position 0 before passing it to load_store.
- Surface meaningful errors from failed store tasks instead of crashing.
- Decode bytes from store state before JSON-parsing.
- Fetch URL content when load_store returns a raw URL string unchanged
  (required for direct assertion URL import).
- Normalize the store value to a dict robustly (dict / str / bytes).
- Reject BadgeClass files with a clear error instead of a silent failure.
- Pass the original URL string to openbadges.verify() when available,
  so the task pipeline handles fetching rather than duplicating it.
- Remove stale TODO comment.