### PR TITLE
Fix/md test findings

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -1285,6 +1285,11 @@ class BadgeClass(
                 self,
             )
 
+        for lp_badge in LearningPathBadge.objects.filter(badge=self):
+            lp = lp_badge.learning_path
+            if lp.learningpathbadge_set.count() <= 2:
+                lp.delete()
+
         issuer = self.issuer
         super(BadgeClass, self).delete(*args, **kwargs)
         issuer.publish(publish_staff=False)
@@ -3428,6 +3433,16 @@ class LearningPath(BaseVersionedEntity, BaseAuditedModel):
         )
         studyLoadJson = json_loads(studyLoadExt.original_json)
         return studyLoadJson["StudyLoad"]
+
+    def delete(self, *args, **kwargs):
+        affected_lp_badges = list(
+            LearningPathBadge.objects.filter(badge=self.participationBadge).exclude(learning_path=self)
+        )
+        for lpb in affected_lp_badges:
+            lpb.delete()
+            if lpb.learning_path.learningpathbadge_set.count() < 2:
+                lpb.learning_path.delete()
+        super().delete(*args, **kwargs)
 
 
 class LearningPathBadge(cachemodel.CacheModel):

--- a/apps/mainsite/badge_pdf.py
+++ b/apps/mainsite/badge_pdf.py
@@ -56,19 +56,25 @@ pdfmetrics.registerFont(TTFont("Rubik-Bold", font_path_rubik_bold))
 pdfmetrics.registerFont(TTFont("Rubik-Italic", font_path_rubik_italic))
 
 
-def get_leaf_badges(lp, visited=None):
-    """Recursively expand nested LPs to their constituent (leaf) badges."""
+def get_leaf_badges(lp, lp_map=None, visited=None):
+    if lp_map is None:
+        all_lps = LearningPath.objects.prefetch_related("learningpathbadge_set")
+        lp_map = {
+            nested_lp.participationBadge_id: nested_lp for nested_lp in all_lps if nested_lp.participationBadge_id
+        }
+
     if visited is None:
         visited = set()
     if lp.pk in visited:
         return []
     visited.add(lp.pk)
+
     badges = []
     for lp_badge in lp.learningpath_badges:
         badge = lp_badge.badge
-        nested_lp = LearningPath.objects.filter(participationBadge=badge).first()
+        nested_lp = lp_map.get(badge.pk)
         if nested_lp:
-            badges.extend(get_leaf_badges(nested_lp, visited))
+            badges.extend(get_leaf_badges(nested_lp, lp_map, visited))
         else:
             badges.append(badge)
     return badges


### PR DESCRIPTION
### Bugs: 
1. PDF for nested LPs only showed LP name, not the badges they consist of. 
Files changed: `apps/mainsite/badge_pdf.py`
(See also pdfeditor repository)
2. If any badge/LP inside an LP is being deleted, leaving the LP with <2 badges, it should be auto deleted. 
Files changed: `apps/issuer/models.py`