### PR TITLE
fix(pdf): change None to empty string in pdf

### DIFF
--- a/apps/mainsite/badge_pdf.py
+++ b/apps/mainsite/badge_pdf.py
@@ -154,7 +154,7 @@ class BadgePDFCreator:
 
         studyload_text = self._format_studyload(studyload_minutes=studyLoad)
         studyload_text = (
-            f"<br />{studyload_text}" if studyload_text is not None else None
+            f"<br />{studyload_text}" if studyload_text is not None else ""
         )
 
         text = _(


### PR DESCRIPTION
[Addresses the following comment](https://github.com/open-educational-badges/badgr-ui/issues/2048#issuecomment-4477985040)