### PR TITLE
fix(learningpath): include competencies in micro degree badges

### DIFF
--- a/apps/issuer/management/commands/backfill_microdegree_competencies.py
+++ b/apps/issuer/management/commands/backfill_microdegree_competencies.py
@@ -1,0 +1,74 @@
+import json
+
+from django.core.management import BaseCommand
+from django.db import transaction
+
+from issuer.models import LearningPath
+
+
+class Command(BaseCommand):
+    help = (
+        "Backfill the competency extension for micro degrees: syncs the aggregated "
+        "path competencies onto each participation badge class and onto already "
+        "issued participation badge assertions"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run", action="store_true", help="Simulate the changes"
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        badgeclasses_updated = 0
+        assertions_updated = 0
+
+        with transaction.atomic():
+            for learningpath in LearningPath.objects.all():
+                competencies = learningpath.competency_extension_items()
+                if not competencies:
+                    continue
+                original_json = json.dumps(competencies)
+
+                if dry_run:
+                    self.stdout.write(
+                        f"DRY-RUN: would sync {len(competencies)} competencies for "
+                        f"learning path '{learningpath.name}'"
+                    )
+                else:
+                    learningpath.sync_participation_badge_competencies()
+                badgeclasses_updated += 1
+
+                assertions = learningpath.participationBadge.badgeinstances.filter(
+                    revoked=False
+                )
+                for assertion in assertions:
+                    if dry_run:
+                        assertions_updated += 1
+                        continue
+                    extension, created = (
+                        assertion.badgeinstanceextension_set.get_or_create(
+                            name="extensions:CompetencyExtension",
+                            defaults={"original_json": original_json},
+                        )
+                    )
+                    if not created:
+                        existing = json.loads(extension.original_json)
+                        if existing:
+                            # assertion already carries competencies; leave it alone
+                            continue
+                        extension.original_json = original_json
+                        extension.save()
+                    assertion.get_json(obi_version="3_0", force_recreate=True)
+                    assertions_updated += 1
+
+            if dry_run:
+                transaction.set_rollback(True)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{'DRY-RUN: would update' if dry_run else 'Updated'} "
+                f"{badgeclasses_updated} participation badge classes and "
+                f"{assertions_updated} assertions"
+            )
+        )

--- a/apps/issuer/managers.py
+++ b/apps/issuer/managers.py
@@ -460,10 +460,8 @@ class BadgeInstanceManager(BaseOpenBadgeObjectManager):
             # all learningpath badges collected but participationBadge not yet issued
             if learningpath.user_should_have_badge(recipient_identifier):
                 # issue learningpath badge
-                learningpath.participationBadge.issue(
-                    recipient_id=recipient_identifier,
-                    notify=notify,
-                    microdegree_id=learningpath.entity_id,
+                learningpath.issue_participation_badge(
+                    recipient_identifier, notify=notify
                 )
 
         return new_instance

--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -2642,15 +2642,17 @@ class BadgeInstance(BaseAuditedModel, BaseVersionedEntity, BaseOpenBadgeObjectMo
                 extension_json = json_loads(extension.original_json)
                 extension_name = extension.name
 
-                try:
-                    extension_context = extension_json["@context"]
-                    if isinstance(extension_context, list):
-                        extension_contexts += extension_context
-                    else:
-                        extension_contexts.append(extension_context)
-
-                except KeyError:
-                    pass
+                # extensions may hold a single object or a list of objects
+                # (e.g. extensions:CompetencyExtension)
+                items = (
+                    extension_json
+                    if isinstance(extension_json, list)
+                    else [extension_json]
+                )
+                for item in items:
+                    if isinstance(item, dict) and "@context" in item:
+                        ctx = item["@context"]
+                        extension_contexts += ctx if isinstance(ctx, list) else [ctx]
 
                 json[extension_name] = extension_json
 
@@ -3479,6 +3481,74 @@ class LearningPath(BaseVersionedEntity, BaseAuditedModel):
         )
         studyLoadJson = json_loads(studyLoadExt.original_json)
         return studyLoadJson["StudyLoad"]
+
+    def competency_extension_items(self):
+        """
+        Aggregate the competencies of all badges in this learning path into a
+        single extensions:CompetencyExtension value. Competencies appearing in
+        multiple badges are merged, summing their studyLoad.
+        """
+        aggregated = OrderedDict()
+        for lp_badge in self.learningpath_badges:
+            for extension in lp_badge.badge.cached_extensions():
+                if extension.name != "extensions:CompetencyExtension":
+                    continue
+                for competency in json_loads(extension.original_json):
+                    key = competency.get("framework_identifier") or (
+                        competency.get("framework"),
+                        competency.get("name"),
+                    )
+                    existing = aggregated.get(key)
+                    if existing is None:
+                        aggregated[key] = dict(competency)
+                    else:
+                        existing["studyLoad"] = existing.get(
+                            "studyLoad", 0
+                        ) + competency.get("studyLoad", 0)
+
+        items = list(aggregated.values())
+        for competency in items:
+            studyload = competency.get("studyLoad")
+            if studyload is not None:
+                competency["hours"] = studyload // 60
+                competency["minutes"] = studyload % 60
+        return items
+
+    def sync_participation_badge_competencies(self):
+        """
+        Store the aggregated path competencies on the participation badge class,
+        so that the micro degree badge class JSON and earner notifications carry
+        them. The UI creates the participation badge with an empty
+        extensions:CompetencyExtension, so this must run whenever the path
+        badges change.
+        """
+        original_json = json_dumps(self.competency_extension_items())
+        extension, created = (
+            self.participationBadge.badgeclassextension_set.get_or_create(
+                name="extensions:CompetencyExtension",
+                defaults={"original_json": original_json},
+            )
+        )
+        if not created:
+            extension.original_json = original_json
+            extension.save()
+
+    def issue_participation_badge(self, recipient_identifier, notify=False):
+        """
+        Issue the micro degree badge with the aggregated path competencies
+        attached as an assertion extension, mirroring how regular awards
+        receive extensions from the award payload.
+        """
+        competencies = self.competency_extension_items()
+        extensions = (
+            {"extensions:CompetencyExtension": competencies} if competencies else None
+        )
+        return self.participationBadge.issue(
+            recipient_id=recipient_identifier,
+            notify=notify,
+            microdegree_id=self.entity_id,
+            extensions=extensions,
+        )
 
     def delete(self, *args, **kwargs):
         affected_lp_badges = list(

--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -1391,6 +1391,7 @@ class LearningPathSerializerV1(ExcludeFieldsMixin, serializers.Serializer):
         new_learningpath.tag_items = tags
 
         new_learningpath.learningpath_badges = badges_with_order
+        new_learningpath.sync_participation_badge_competencies()
         return new_learningpath
 
     def update(self, instance, validated_data):
@@ -1422,6 +1423,7 @@ class LearningPathSerializerV1(ExcludeFieldsMixin, serializers.Serializer):
                 badges_with_order.append((badge, order))
 
             instance.learningpath_badges = badges_with_order
+            instance.sync_participation_badge_competencies()
 
         instance.save()
 

--- a/apps/issuer/tests/test_learningpath_competencies.py
+++ b/apps/issuer/tests/test_learningpath_competencies.py
@@ -1,0 +1,153 @@
+import json
+import os
+
+from django.test import override_settings
+
+from issuer import jsonld_loader
+from issuer.models import BadgeClass, Issuer, LearningPath, LearningPathBadge
+from mainsite import TOP_DIR
+from mainsite.tests.base import BadgrTestCase
+
+COMPETENCY_CONTEXT_URL = (
+    "http://example.test/extensions/CompetencyExtension/context.json"
+)
+
+
+def competency(name, framework_identifier="", study_load=60):
+    return {
+        "@context": COMPETENCY_CONTEXT_URL,
+        "type": ["Extension", "extensions:CompetencyExtension"],
+        "name": name,
+        "description": "%s description" % name,
+        "framework": "esco" if framework_identifier else "",
+        "framework_identifier": framework_identifier,
+        "source": "manual",
+        "studyLoad": study_load,
+        "category": "skill",
+    }
+
+
+ESCO_URI = "http://data.europa.eu/esco/skill/test-skill"
+
+
+@override_settings(
+    MEDIA_ROOT=os.path.join(TOP_DIR, "apps/mainsite/tests/testfiles"),
+    # notifying the earner renders the badge PDF, which needs badgeclass
+    # extensions this test's minimal badgeclasses do not have
+    GDPR_COMPLIANCE_NOTIFY_ON_FIRST_AWARD=False,
+)
+class LearningPathCompetencyTests(BadgrTestCase):
+    def setUp(self):
+        super().setUp()
+
+        # the OB 3.0 JSON-LD normalization resolves the extension's @context;
+        # serve the repo's own context file instead of hitting the network
+        with open(
+            os.path.join(
+                TOP_DIR,
+                "apps/mainsite/static/extensions/CompetencyExtension/context.json",
+            )
+        ) as f:
+            jsonld_loader._doc_cache[COMPETENCY_CONTEXT_URL] = {
+                "contextUrl": None,
+                "documentUrl": COMPETENCY_CONTEXT_URL,
+                "document": json.load(f),
+            }
+
+        self.user = self.setup_user(email="issuer@example.test", token_scope="rw:issuer")
+        self.issuer = Issuer.objects.create(
+            name="Test Issuer",
+            verified=True,
+            email="issuer@example.test",
+            url="http://example.test",
+            linkedinId="",
+            created_by=self.user,
+        )
+
+        self.badge_one = self._badgeclass(
+            "Badge One",
+            [competency("Skill A", ESCO_URI, 60), competency("Skill B", "", 30)],
+        )
+        self.badge_two = self._badgeclass(
+            "Badge Two",
+            [competency("Skill A", ESCO_URI, 45), competency("Skill C", "", 15)],
+        )
+
+        self.participation_badge = self._badgeclass("Test MD Badge", [])
+
+        self.lp = LearningPath.objects.create(
+            name="Test LP",
+            issuer=self.issuer,
+            participationBadge=self.participation_badge,
+            activated=True,
+            required_badges_count=2,
+            description="test",
+        )
+        LearningPathBadge.objects.create(
+            learning_path=self.lp, badge=self.badge_one, order=0
+        )
+        LearningPathBadge.objects.create(
+            learning_path=self.lp, badge=self.badge_two, order=1
+        )
+
+    def _badgeclass(self, name, competencies):
+        badgeclass = BadgeClass.objects.create(
+            name=name,
+            issuer=self.issuer,
+            image="badge.png",
+            description="test",
+            imageFrame=False,
+        )
+        badgeclass.badgeclassextension_set.create(
+            name="extensions:CompetencyExtension",
+            original_json=json.dumps(competencies),
+        )
+        return badgeclass
+
+    def test_competencies_are_aggregated_and_deduplicated(self):
+        items = self.lp.competency_extension_items()
+
+        self.assertEqual(
+            sorted(item["name"] for item in items),
+            ["Skill A", "Skill B", "Skill C"],
+        )
+
+        skill_a = next(item for item in items if item["name"] == "Skill A")
+        self.assertEqual(skill_a["studyLoad"], 105)
+        self.assertEqual(skill_a["hours"], 1)
+        self.assertEqual(skill_a["minutes"], 45)
+
+    def test_auto_issued_micro_degree_carries_competencies(self):
+        recipient = "recipient@example.test"
+        self.badge_one.issue(recipient_id=recipient)
+        self.badge_two.issue(recipient_id=recipient)
+
+        assertion = self.participation_badge.badgeinstances.get(
+            recipient_identifier=recipient
+        )
+        extension = assertion.badgeinstanceextension_set.get(
+            name="extensions:CompetencyExtension"
+        )
+        competencies = json.loads(extension.original_json)
+        self.assertEqual(
+            sorted(item["name"] for item in competencies),
+            ["Skill A", "Skill B", "Skill C"],
+        )
+
+        assertion_json = assertion.get_json(obi_version="2_0")
+        self.assertEqual(
+            sorted(
+                item["name"]
+                for item in assertion_json["extensions:CompetencyExtension"]
+            ),
+            ["Skill A", "Skill B", "Skill C"],
+        )
+
+    def test_sync_participation_badge_competencies(self):
+        self.lp.sync_participation_badge_competencies()
+
+        extension = self.participation_badge.badgeclassextension_set.get(
+            name="extensions:CompetencyExtension"
+        )
+        competencies = json.loads(extension.original_json)
+        self.assertEqual(len(competencies), 3)

--- a/apps/mainsite/tasks.py
+++ b/apps/mainsite/tasks.py
@@ -18,11 +18,7 @@ def process_learning_path_activation(pk):
         for user in BadgeUser.objects.all():
             for identifier in user.all_verified_recipient_identifiers:
                 if learning_path.user_should_have_badge(identifier):
-                    learning_path.participationBadge.issue(
-                        recipient_id=identifier,
-                        notify=True,
-                        microdegree_id=learning_path.entity_id,
-                    )
+                    learning_path.issue_participation_badge(identifier, notify=True)
 
         return f"Successfully processed learning path activation for {pk}"
 


### PR DESCRIPTION
## Summary

Fixes the server side of open-educational-badges/badgr-ui#2208 — micro degree (learning path participation) badges were issued without any competencies in their JSON.

Root cause was two-layered: the auto-issue call sites never passed `extensions` (so no `BadgeInstanceExtension` rows were created and the assertion JSON was empty), and the participation badge class itself was created by the UI with a hardcoded empty `extensions:CompetencyExtension` (fixed separately in the companion badgr-ui PR).

## Changes

- `LearningPath.competency_extension_items()` aggregates the competencies of all path badges, deduplicated by framework identifier (falling back to framework + name), with `studyLoad` summed — the same summing rule the skills tree in `backpack/utils.py` uses
- `LearningPath.issue_participation_badge()` attaches the aggregation as an assertion extension; both auto-issue call sites (`issuer/managers.py` on badge collection, `mainsite/tasks.py` on path activation) now go through it
- `LearningPathSerializerV1.create()/update()` sync the aggregation onto the participation badge class, so the badge class JSON, backpack representation and earner notification emails carry the competencies regardless of UI version
- fixes a latent `TypeError` in `BadgeInstance.get_json_3_0()` for list-valued assertion extensions (`CompetencyExtension` is a list); contexts are now extracted the same way as in the badge class extension block
- new `backfill_microdegree_competencies` management command (supports `--dry-run`) to repair already issued micro degrees — **run once after deploy**

## Notes for review

Competencies aggregate from **all** path badges, not only the ones a recipient completed. Since `required_badges_count` allows earning the micro degree from a subset, a recipient can be credited competencies from badges they did not earn — this matches how the UI already presents learning path competencies. If per-recipient aggregation is preferred, `issue_participation_badge()` is the single place to change.

## Tests

- new `issuer/tests/test_learningpath_competencies.py` covering aggregation/dedup/studyLoad summing, the auto-issued assertion carrying competencies (instance extension + OB 2.0 JSON), and the badge class sync
- full `issuer` + `backpack` suites pass (31 tests)
- backfill command verified with `--dry-run`