### PR TITLE
fix(pdf): sum shared competency study load across micro degree badges

### DIFF
--- a/apps/mainsite/badge_pdf.py
+++ b/apps/mainsite/badge_pdf.py
@@ -569,8 +569,29 @@ class BadgePDFCreator:
                         "extensions:CompetencyExtension"
                     ]
                     for competency in competencies:
-                        if competency not in self.competencies:
-                            self.competencies.append(competency)
+                        key = competency.get("framework_identifier") or (
+                            competency.get("framework"),
+                            competency.get("name"),
+                        )
+                        existing = next(
+                            (
+                                c
+                                for c in self.competencies
+                                if (
+                                    c.get("framework_identifier")
+                                    or (c.get("framework"), c.get("name"))
+                                )
+                                == key
+                            ),
+                            None,
+                        )
+                        if existing is None:
+                            # copy so summing never mutates the cached badge json
+                            self.competencies.append(dict(competency))
+                        else:
+                            existing["studyLoad"] = existing.get(
+                                "studyLoad", 0
+                            ) + competency.get("studyLoad", 0)
 
                 if i != 0 and i % badgesPerPage == 0:
                     Story.append(PageBreak())


### PR DESCRIPTION
## Problem

In the micro degree badge PDF, a competency shared by several badges of the learning path (e.g. "Design Thinking" appearing in 4 badges, each 1:00 h) was shown only once with a single badge's study load (1:00 h) instead of the summed total (4:00 h). Nested micro degrees were affected the same way.

Fixes open-educational-badges/badgr-ui#2209

## Cause

`BadgePDFCreator.add_learningpath_badges` (base certificate PDF) collected competencies with a `if competency not in self.competencies` check, which **dropped** duplicates rather than **summing** their `studyLoad`.

## Fix

Aggregate competencies by `framework_identifier` (falling back to `(framework, name)`) and add up `studyLoad`, working on a copy so the cached badge JSON is never mutated. This matches the merge key already used by `LearningPath.competency_extension_items()`.

The template PDF (`badgr-server-plugin-pdfeditor`) — which is the one in the issue screenshots — carries the same fix in its own PR.

## Notes

- Nested micro degrees rely on each sub-MD's participation badge carrying its aggregated competencies (populated by the #2208 sync going forward). Existing pre-#2208 micro degrees need `backfill_microdegree_competencies` run to show correct totals.

## Testing

`manage.py test issuer.tests.test_learningpath_competencies` and the plugin's new PDF summing tests pass (7/7).