### PR TITLE
fix(learningpath): show recipient date of birth on micro degree PDF

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -3533,6 +3533,24 @@ class LearningPath(BaseVersionedEntity, BaseAuditedModel):
             extension.original_json = original_json
             extension.save()
 
+    def recipient_date_of_birth(self, recipient_identifier):
+        """
+        Reuse the recipient's date of birth from the path badges they earned so
+        the micro degree PDF can show it like the individual badge PDFs do.
+        """
+        badgeclasses = [lp_badge.badge for lp_badge in self.learningpath_badges]
+        instance = (
+            BadgeInstance.objects.filter(
+                recipient_identifier=recipient_identifier,
+                badgeclass__in=badgeclasses,
+                revoked=False,
+                date_of_birth__isnull=False,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        return instance.date_of_birth if instance else None
+
     def issue_participation_badge(self, recipient_identifier, notify=False):
         """
         Issue the micro degree badge with the aggregated path competencies
@@ -3548,6 +3566,7 @@ class LearningPath(BaseVersionedEntity, BaseAuditedModel):
             notify=notify,
             microdegree_id=self.entity_id,
             extensions=extensions,
+            date_of_birth=self.recipient_date_of_birth(recipient_identifier),
         )
 
     def delete(self, *args, **kwargs):


### PR DESCRIPTION
Fixes part of open-educational-badges/badgr-ui#2182 (date of birth not displayed on the micro degree PDF).

When a learner completes a micro degree, the participation badge is auto-issued by `LearningPath.issue_participation_badge()` — but it never passed `date_of_birth`, so the instance had none and the PDF omitted the line.

- Add `LearningPath.recipient_date_of_birth()`, which reuses the DOB from the recipient's completed path badges (most recent one that has it set).
- Pass it into the `participationBadge.issue(...)` call.

Works for both issuance paths — a badge award that completes a path (`managers.py`) and learning-path activation backfill (`tasks.py`).

Note: only affects newly issued micro degrees; already-awarded participation badges are not backfilled.

Paired with mycelia-gGmbH/waffle#11 which unifies the cover text font size to 12pt on the template PDFs.