### PR TITLE
fix(pdf): match recipient detail text size to date of birth line

### DIFF
--- a/apps/mainsite/badge_pdf.py
+++ b/apps/mainsite/badge_pdf.py
@@ -148,9 +148,9 @@ class BadgePDFCreator:
 
         text_style = ParagraphStyle(
             name="Text_Style",
-            fontSize=14,
+            fontSize=12,
             alignment=TA_CENTER,
-            leading=18.2,  # 130%
+            leading=15.6,  # 130%
         )
 
         if (


### PR DESCRIPTION
## Summary

On the certificate PDF, the date-of-birth line ("geboren am …") rendered at 12pt while the activity/date lines directly below it ("hat vom … online", "innerhalb von … Stunde", "den folgenden Badge erworben:") rendered at 14pt, giving an inconsistent look.

This reduces the recipient detail text to 12pt to match the date-of-birth line, per the reviewer's suggestion — which also saves vertical space on the first page.

## Context

Follow-up to the date-of-birth work for [badgr-ui#2182](https://github.com/open-educational-badges/badgr-ui/issues/2182). The missing DOB on the micro-degree PDF was already fixed (#804); this addresses the remaining font-size mismatch reported [here](https://github.com/open-educational-badges/badgr-ui/issues/2182#issuecomment-5047064304).

## Changes

- `apps/mainsite/badge_pdf.py`: recipient detail `text_style` changed from `fontSize=14, leading=18.2` to `fontSize=12, leading=15.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)